### PR TITLE
[KAN-2] Stub /onboarding/[role] pour éviter le 404 après choix de rôle

### DIFF
--- a/apps/web/app/(auth)/onboarding/[role]/page.tsx
+++ b/apps/web/app/(auth)/onboarding/[role]/page.tsx
@@ -1,0 +1,87 @@
+import { Role } from "@delta/contracts/auth"
+import Link from "next/link"
+import { notFound, redirect } from "next/navigation"
+
+import { getServerSupabase } from "@/lib/supabase/server"
+
+// Page dépendante de la session utilisateur → pas de pré-rendu statique
+// (cf. /onboarding/role/page.tsx).
+export const dynamic = "force-dynamic"
+
+type Params = Promise<{ role: string }>
+
+const ROLE_LABELS: Record<Role, string> = {
+  acheteur: "Acheteur",
+  rameneur: "Rameneur",
+  producteur: "Producteur",
+}
+
+// Tickets Jira qui livreront l'onboarding réel de chaque rôle (cf.
+// specs/KAN-2/design.md « Out of scope »).
+const ROLE_TICKETS: Record<Role, string> = {
+  acheteur: "KAN-25",
+  rameneur: "KAN-37",
+  producteur: "KAN-16",
+}
+
+export async function generateMetadata(props: { params: Params }) {
+  const { role } = await props.params
+  const parsed = Role.safeParse(role)
+  if (!parsed.success) return { title: "Onboarding — Delta" }
+  return { title: `Onboarding ${ROLE_LABELS[parsed.data]} — Delta` }
+}
+
+export default async function OnboardingRolePlaceholderPage(props: {
+  params: Params
+}) {
+  const { role } = await props.params
+  const parsed = Role.safeParse(role)
+  if (!parsed.success) notFound()
+
+  const supabase = await getServerSupabase()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) redirect("/signup")
+
+  const label = ROLE_LABELS[parsed.data]
+  const ticket = ROLE_TICKETS[parsed.data]
+
+  return (
+    <section className="flex flex-col gap-7">
+      <header className="flex flex-col gap-2">
+        <p className="font-body text-sm uppercase tracking-[0.04em] text-cream-600">
+          Rôle {label.toLowerCase()}
+        </p>
+        <h1 className="font-display text-3xl font-semibold leading-tight tracking-tight text-cream-950">
+          Onboarding {label} — bientôt
+        </h1>
+        <p className="font-body text-md leading-relaxed text-cream-700">
+          Votre compte est créé et votre rôle enregistré. La suite de
+          l&apos;onboarding {label.toLowerCase()} arrive dans le ticket{" "}
+          {ticket}.
+        </p>
+      </header>
+      <div className="flex flex-col gap-3 rounded-2xl bg-cream-100 px-5 py-5">
+        <p className="font-body text-sm text-cream-800">
+          En attendant, vous pouvez revenir à l&apos;accueil ou choisir un autre
+          rôle.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href="/welcome"
+            className="inline-flex items-center justify-center rounded-full bg-green-700 px-5 py-2.5 font-body text-sm font-semibold text-cream-50 hover:bg-green-800"
+          >
+            Retour à l&apos;accueil
+          </Link>
+          <Link
+            href="/onboarding/role"
+            className="inline-flex items-center justify-center rounded-full border border-cream-300 px-5 py-2.5 font-body text-sm font-semibold text-cream-900 hover:bg-cream-200"
+          >
+            Modifier mes rôles
+          </Link>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/specs/KAN-2/tasks.md
+++ b/specs/KAN-2/tasks.md
@@ -40,6 +40,10 @@
 - [ ] Tests Vitest : refondus pour le nouveau périmètre (multi-rôle, OTP, splash).
 - [ ] Mise à jour des .md transverses (CLAUDE.md, ARCHITECTURE.md §18 entrée 1.13, jira_mapping si nécessaire).
 
+### Phase 2bis — Stub onboardings (commit suivant)
+
+- [x] Page `apps/web/app/(auth)/onboarding/[role]/page.tsx` — stub dynamique pour `acheteur`/`rameneur`/`producteur` afin de fermer la boucle KAN-2 (sinon 404 après `nextOnboardingPath`). Pointe vers les tickets qui porteront le vrai écran : KAN-25 (AC-02), KAN-37 (RM-02), KAN-16 (PR-02).
+
 ### Phase 3 — Reportées (sessions ultérieures)
 
 - [ ] Seeds dev : 3 users (un par rôle) pour tests locaux — conditionné à `apps/mobile`.


### PR DESCRIPTION
## Contexte

Après merge de KAN-2 sur `main`, le flow auth fonctionne jusqu'à `/onboarding/role` inclus. Mais une fois le rôle choisi, `PATCH /api/v1/me/roles` répond OK puis le client redirige via `nextOnboardingPath(roles)` vers `/onboarding/producteur` (ou `acheteur` / `rameneur`) — pages qui n'existent pas, d'où un **404**.

Ces écrans sont hors scope KAN-2 (cf. `specs/KAN-2/design.md` → KAN-16 PR-02, KAN-25 AC-02, KAN-37 RM-02), mais sans stub la boucle KAN-2 n'est pas refermée pour les utilisateurs qui testent le preview.

## Changement

Une seule route dynamique `apps/web/app/(auth)/onboarding/[role]/page.tsx` :

- Valide le segment avec le schéma Zod `Role` (`acheteur` / `rameneur` / `producteur`) → `notFound()` sinon.
- Garde la session Supabase, redirige vers `/signup` si non connecté (même pattern que `/onboarding/role`).
- Affiche un placeholder « Onboarding {Rôle} — bientôt » qui cite explicitement le ticket Jira qui livrera le vrai écran.
- Deux CTA : retour `/welcome` et `/onboarding/role` (changer ses rôles).
- `force-dynamic` (mêmes raisons que `/onboarding/role` : env vars Supabase absentes au build CI).

Une nouvelle phase « 2bis — Stub onboardings » est ajoutée à `specs/KAN-2/tasks.md` pour tracer ce bridge.

## Vérifications locales

- `pnpm -w typecheck` → vert (5/5 packages)
- `pnpm -w lint` → vert (5/5 packages)
- `pnpm -w test` → vert (57 tests Vitest)
- Le build Next échoue dans le sandbox uniquement faute d'accès Google Fonts (TLS) — sans rapport avec ce changement, à valider sur CI.

## Test plan

- [ ] Sur le preview Vercel, parcours complet : `/welcome` → `/signup` → OTP → `/onboarding/role`, cocher **Producteur** → arrive sur `/onboarding/producteur` (stub affiché, plus de 404).
- [ ] Idem en cochant **Acheteur** seul → `/onboarding/acheteur`.
- [ ] Idem **Rameneur** seul → `/onboarding/rameneur`.
- [ ] Multi-rôle (rameneur + producteur) → arrive sur `/onboarding/rameneur` (priorité rameneur).
- [ ] `/onboarding/foo` → 404 (validation Zod du segment).
- [ ] `/onboarding/producteur` sans session → redirige vers `/signup`.
- [ ] CTA « Modifier mes rôles » → retour `/onboarding/role`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFRB8pH4Zk2Kw1nDSB8GrK)_