### PR TITLE
[KAN-2] Coche Phase 2 + 2bis dans tasks.md (clôture spec)

### DIFF
--- a/specs/KAN-2/tasks.md
+++ b/specs/KAN-2/tasks.md
@@ -21,26 +21,26 @@
 
 ### Phase 2 — Réalignement maquette (décisions produit 2026-05-13)
 
-- [ ] Migration DB additive : `users.role user_role` → `users.roles user_role[] NOT NULL DEFAULT '{}'`. Trigger : ne plus pré-affecter de rôle (vide). Repercussions sur policy UPDATE (autoriser self-update de `roles` ; toujours interdire self-update de `email`/`id`).
-- [ ] Schémas Zod refondus : `SignupInput` (email + password + termsVersion + privacyVersion, **plus de role, plus de checkboxes**). Nouveau `RoleSelectionInput { roles: Role[] (1..3 distinct) }`. Nouveau `OtpVerificationInput { email, otp 6 digits }`.
-- [ ] Repo `usersRepo` : `updateRoles(client, id, roles[])` à la place de `updateRole`.
-- [ ] Use case core `applyRoleSelection` (validation 1..3 distincts) + tests.
-- [ ] **Composant `Splash`** (AU-01) — photo background, hero, 2 CTAs, mention CGU implicite.
-- [ ] **Page `/welcome`** — Server Component qui monte `Splash`.
-- [ ] **Composant `SignupForm` v2** — email + password + bouton Google **en premier**, séparateur, hint password (10 caractères + maj/min/digit), bandeau « Vos données restent en France ». Plus de checkboxes consents. Plus de radios rôle.
-- [ ] **Page `/signup` v2** — Server Component shell + `SignupForm` v2. Soumet vers `/api/v1/auth/signup` (sans role).
-- [ ] **Composant `OtpForm`** (AU-04) — 6 cases auto-focus, validation côté client (digits only), CTA « Vérifier ».
-- [ ] **Page `/auth/verify-email`** — Client Component qui consomme `supabase.auth.verifyOtp({ type: 'email' })` + `supabase.auth.resend`.
-- [ ] **Composant `RoleSelector` + `RoleCard`** (AU-06) — 3 cards multi-select, badge « Email vérifié », info-block multi-rôle.
-- [ ] **Page `/onboarding/role`** — Client Component qui PATCH `/api/v1/me/roles` puis redirige selon priorité (rameneur > producteur > acheteur).
-- [ ] Route handler `/api/v1/auth/signup` v2 — sans role, ajoute `consents` au `raw_user_meta_data` pour le trigger.
-- [ ] Route handler `/api/v1/me/roles` (PATCH) — applique `applyRoleSelection`.
-- [ ] Callback OAuth `/auth/callback` v2 — pose `metadata.consents` si absent (Google ne passe pas par /signup), redirige vers `/onboarding/role` si `users.roles` est vide.
-- [ ] Page `apps/web/app/page.tsx` (landing actuelle) : ajouter un lien vers `/welcome` pour l'entrée du flow auth (sans toucher à son contenu actuel).
-- [ ] Tests Vitest : refondus pour le nouveau périmètre (multi-rôle, OTP, splash).
-- [ ] Mise à jour des .md transverses (CLAUDE.md, ARCHITECTURE.md §18 entrée 1.13, jira_mapping si nécessaire).
+- [x] Migration DB additive : `users.role user_role` → `users.roles user_role[] NOT NULL DEFAULT '{}'`. Trigger : ne plus pré-affecter de rôle (vide). Repercussions sur policy UPDATE (autoriser self-update de `roles` ; toujours interdire self-update de `email`/`id`).
+- [x] Schémas Zod refondus : `SignupInput` (email + password + termsVersion + privacyVersion, **plus de role, plus de checkboxes**). Nouveau `RoleSelectionInput { roles: Role[] (1..3 distinct) }`. Nouveau `OtpVerificationInput { email, otp 6 digits }`.
+- [x] Repo `usersRepo` : `updateRoles(client, id, roles[])` à la place de `updateRole`.
+- [x] Use case core `applyRoleSelection` (validation 1..3 distincts) + tests.
+- [x] **Composant `Splash`** (AU-01) — photo background, hero, 2 CTAs, mention CGU implicite.
+- [x] **Page `/welcome`** — Server Component qui monte `Splash`.
+- [x] **Composant `SignupForm` v2** — email + password + bouton Google **en premier**, séparateur, hint password (10 caractères + maj/min/digit), bandeau « Vos données restent en France ». Plus de checkboxes consents. Plus de radios rôle.
+- [x] **Page `/signup` v2** — Server Component shell + `SignupForm` v2. Soumet vers `/api/v1/auth/signup` (sans role).
+- [x] **Composant `OtpForm`** (AU-04) — 6 cases auto-focus, validation côté client (digits only), CTA « Vérifier ».
+- [x] **Page `/auth/verify-email`** — Client Component qui consomme `supabase.auth.verifyOtp({ type: 'email' })` + `supabase.auth.resend`.
+- [x] **Composant `RoleSelector` + `RoleCard`** (AU-06) — 3 cards multi-select, badge « Email vérifié », info-block multi-rôle.
+- [x] **Page `/onboarding/role`** — Client Component qui PATCH `/api/v1/me/roles` puis redirige selon priorité (rameneur > producteur > acheteur).
+- [x] Route handler `/api/v1/auth/signup` v2 — sans role, ajoute `consents` au `raw_user_meta_data` pour le trigger.
+- [x] Route handler `/api/v1/me/roles` (PATCH) — applique `applyRoleSelection`.
+- [x] Callback OAuth `/auth/callback` v2 — pose `metadata.consents` si absent (Google ne passe pas par /signup), redirige vers `/onboarding/role` si `users.roles` est vide.
+- [x] Page `apps/web/app/page.tsx` (landing actuelle) : ajouter un lien vers `/welcome` pour l'entrée du flow auth (sans toucher à son contenu actuel).
+- [x] Tests Vitest : refondus pour le nouveau périmètre (multi-rôle, OTP, splash) — 57 tests verts.
+- [x] Mise à jour des .md transverses (CLAUDE.md, ARCHITECTURE.md §18 entrée 1.13, jira_mapping si nécessaire).
 
-### Phase 2bis — Stub onboardings (commit suivant)
+### Phase 2bis — Stub onboardings (PR #3)
 
 - [x] Page `apps/web/app/(auth)/onboarding/[role]/page.tsx` — stub dynamique pour `acheteur`/`rameneur`/`producteur` afin de fermer la boucle KAN-2 (sinon 404 après `nextOnboardingPath`). Pointe vers les tickets qui porteront le vrai écran : KAN-25 (AC-02), KAN-37 (RM-02), KAN-16 (PR-02).
 


### PR DESCRIPTION
## Contexte

Phase 2 (réalignement 4 écrans + multi-rôle) et Phase 2bis (stub `/onboarding/[role]`) sont mergées sur `main` depuis les PRs précédentes, mais `specs/KAN-2/tasks.md` n'avait jamais été mise à jour pour cocher les items au fur et à mesure. Ce PR aligne la spec sur la réalité du repo pour clôturer proprement KAN-2.

## Changement

`specs/KAN-2/tasks.md` :
- 18 cases cochées sur Phase 2 (audit fait contre `main`)
- 1 case déjà cochée sur Phase 2bis, renommée `(PR #3)` pour traçabilité
- Phase 3 inchangée (Apple Sign In, seeds mobile, test helper — conditionnés et hors clôture KAN-2)

Aucun code touché.

## Test plan

- [ ] Visuel : la spec reflète l'état réel du repo


---
_Generated by [Claude Code](https://claude.ai/code/session_01KFRB8pH4Zk2Kw1nDSB8GrK)_