### PR TITLE
Sync statut projet et arborescence après merge KAN-2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,10 @@ Charge ce fichier à l'ouverture du projet pour comprendre rapidement où on en 
 ## Statut
 
 - **Phase** : conception produit, pré-développement
-- **Maquettes** : 11 écrans prioritaires posés (rameneur, producteur, acheteur). Avancement détaillé sur Jira (projet KAN).
+- **Maquettes** : 36 écrans cartographiés sur les 3 parcours (acheteur 15, producteur 9, rameneur 12). Index navigable : `design/maquettes/index.html`. Avancement détaillé sur Jira (projet KAN).
 - **Décisions structurantes** : prises (voir ci-dessous)
 - **Backlog** : structuré sur Jira (erkulaws.atlassian.net, projet KAN) — épics, features et subtasks créés pour l'ensemble du MVP
-- **Code** : pas commencé
+- **Code** : KAN-2 (création de compte) livré sur main — `/welcome`, `/signup`, `/auth/verify-email`, `/onboarding/role` + stubs `/onboarding/[role]`. Reste à attaquer : KAN-3 (connexion), KAN-157 (mot de passe oublié), puis onboardings par rôle (KAN-16 / KAN-25 / KAN-37).
 
 ## Modèle d'expérience (important — flip vs PRD initial)
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Delta/
 ├── legal/               CGU, CGV, RGPD (à venir)
 ├── business/            Modèle économique, pricing, ops (à venir)
 │
-├── apps/                web (Next.js 15, signup KAN-2 en place), mobile (Expo) — à venir
-├── packages/            contracts, core, db, ui-web (scaffold KAN-2) ; ui-mobile, design-tokens, api-client, jobs à venir
+├── apps/                web (Next.js 15, flow auth KAN-2 livré : welcome / signup / verify-email / onboarding role) ; mobile (Expo) à venir
+├── packages/            contracts, core, db, ui-web (auth complet KAN-2) ; ui-mobile, design-tokens, api-client, jobs à venir
 └── supabase/            Config CLI, migrations versionnées, seeds, policies SQL
     ├── config.toml      Config locale Supabase CLI
     ├── migrations/      Migrations SQL horodatées (YYYYMMDDHHMMSS_*.sql)


### PR DESCRIPTION
## Contexte

Trois passages `.md` étaient désynchronisés après le merge des PRs KAN-2 (#3, #4, #5) et l'ajout des maquettes manquantes.

## Changement

**`CLAUDE.md` § Statut :**

- « 11 écrans prioritaires posés » → « 36 écrans cartographiés sur les 3 parcours (acheteur 15, producteur 9, rameneur 12) » + référence à l'index `design/maquettes/index.html`
- « Code : pas commencé » → liste des routes KAN-2 livrées (`/welcome`, `/signup`, `/auth/verify-email`, `/onboarding/role` + stubs `/onboarding/[role]`) et prochains tickets identifiés (KAN-3, KAN-157, KAN-16/25/37)

**`README.md` arborescence :**

- `apps/` : « signup KAN-2 en place » → « flow auth KAN-2 livré (welcome / signup / verify-email / onboarding role) »
- `packages/` : « ui-web (scaffold KAN-2) » → « ui-web (auth complet KAN-2) »

Aucune autre `.md` n'a besoin de mise à jour : `ARCHITECTURE.md` §18 (1.14), `specs/KAN-2/tasks.md` (phase 4) et `produit/jira_mapping.md` étaient déjà à jour, et `DESIGN.md` n'est pas concerné (pas de tokens / breakpoints / règles design touchés par cette refonte).

## Test plan

- [ ] Lecture humaine : les sections « Statut » de `CLAUDE.md` et l'arborescence du `README.md` reflètent l'état réel du repo.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KFRB8pH4Zk2Kw1nDSB8GrK)_