### PR TITLE
docs: add KAN-157 (password recovery) to auth mockup headers

### DIFF
--- a/design/maquettes/acheteur/ac-01-authentication.html
+++ b/design/maquettes/acheteur/ac-01-authentication.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <!--
   Maquette Delta — AC-01 Inscription / connexion acheteur
-  Ticket(s) Jira : KAN-2 (Création de compte), KAN-3 (Connexion)
+  Ticket(s) Jira : KAN-2 (Création de compte), KAN-3 (Connexion), KAN-157 (Récup. mot de passe)
   Mapping complet : produit/jira_mapping.md
 -->
 <html>

--- a/design/maquettes/producteur/pr-01-authentication.html
+++ b/design/maquettes/producteur/pr-01-authentication.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <!--
   Maquette Delta — PR-01 Inscription / connexion producteur
-  Ticket(s) Jira : KAN-2 (Création de compte), KAN-3 (Connexion)
+  Ticket(s) Jira : KAN-2 (Création de compte), KAN-3 (Connexion), KAN-157 (Récup. mot de passe)
   Mapping complet : produit/jira_mapping.md
 -->
 <html>

--- a/design/maquettes/rameneur/rm-01-authentication.html
+++ b/design/maquettes/rameneur/rm-01-authentication.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <!--
   Maquette Delta — RM-01 Inscription / connexion rameneur
-  Ticket(s) Jira : KAN-2 (Création de compte), KAN-3 (Connexion)
+  Ticket(s) Jira : KAN-2 (Création de compte), KAN-3 (Connexion), KAN-157 (Récup. mot de passe)
   Mapping complet : produit/jira_mapping.md
 -->
 <html>


### PR DESCRIPTION
## Summary
Updated the Jira ticket references in the HTML headers of all three authentication mockups (acheteur, producteur, rameneur) to include KAN-157, which covers password recovery functionality.

## Changes
- **design/maquettes/acheteur/ac-01-authentication.html**: Added KAN-157 (Récup. mot de passe) to ticket list
- **design/maquettes/producteur/pr-01-authentication.html**: Added KAN-157 (Récup. mot de passe) to ticket list
- **design/maquettes/rameneur/rm-01-authentication.html**: Added KAN-157 (Récup. mot de passe) to ticket list

## Details
These mockups now correctly reference all three authentication-related tickets in the MVP:
- KAN-2: Création de compte (account creation)
- KAN-3: Connexion (login)
- KAN-157: Récup. mot de passe (password recovery)

This aligns the mockup documentation with the current backlog structure and ensures the mapping in `produit/jira_mapping.md` remains accurate.

https://claude.ai/code/session_01J2CYe7y8iq3ZFAB5Hho8e6