### PR TITLE
Mapping Jira : KAN-16 en Terminé (merge PR #10)

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -9,7 +9,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 - **13 épics** (KAN-1, KAN-4 → KAN-15) — un épic par grand domaine fonctionnel
 - **49 features cataloguées** (KAN-2, KAN-3 sous KAN-1 ; KAN-16 → KAN-157 sous les autres épics — voir tables par épic ci-dessous)
 - **Subtasks** : voir le catalogue par épic ci-dessous. Le mapping peut être incomplet pour les subtasks les plus récentes — Jira fait foi pour la liste exhaustive.
-- État au 2026-05-17 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Wip* (implémentation web sur `claude/propose-kan-16-pAM82`, cadrage `specs/KAN-16/`, PR #10) ; autres *Ideas*
+- État au 2026-05-17 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; autres *Ideas*
 - **Maquettes (2026-05-14)** : les 35 écrans des 3 parcours (Producteur, Acheteur, Rameneur) du sitemap PRD §10 sont maquettés. Restent à maquetter : transverses **TR-02** (centre notifications) et **TR-04** (signalement / litige) ; **TR-03** est couvert par `rm-09-chat.html`. Index navigable de toutes les maquettes : `design/maquettes/index.html`
 
 ## Convention de référencement
@@ -101,7 +101,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | Ticket | Type | Statut | Résumé |
 |--------|------|--------|--------|
 | KAN-4 | Epic | Ideas | Profil Producteur |
-| KAN-16 | Feature | Wip | Onboarding Stripe Connect — [Cadrage tech](specs/KAN-16/) — implémentation sur `claude/propose-kan-16-pAM82` |
+| KAN-16 | Feature | Terminé | Onboarding Stripe Connect — [Cadrage tech](specs/KAN-16/) — mergé sur main (PR #10) |
 | KAN-17 | Feature | Ideas | Informations profil & ferme |
 | KAN-18 | Feature | Ideas | Tableau de bord producteur |
 | KAN-19 | Feature | Ideas | Historique ventes |


### PR DESCRIPTION
Sync mapping après merge de [PR #10](https://github.com/Erkkul/delta/pull/10) (KAN-16 Onboarding producteur).

Deux lignes touchées dans `produit/jira_mapping.md` :
- **Catalogue KAN-4** : statut KAN-16 passe `Wip` → `Terminé` avec mention PR #10
- **Vue d'ensemble (« État au »)** : KAN-16 rejoint KAN-2/3/157 dans le bucket Terminé

Jira a été transitionné en `Terminé` côté ticket en parallèle.

Suit la règle [« Après merge d'une feature sur main »](https://github.com/Erkkul/delta/blob/main/CLAUDE.md) (ajoutée à CLAUDE.md sur main il y a peu).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdvmNKEngBQJBpW4Bmi7Jb)_