### PR TITLE
[KAN-158] ouverture cadrage

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -105,7 +105,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | KAN-17 | Feature | Ideas | Informations profil & ferme |
 | KAN-18 | Feature | Ideas | Tableau de bord producteur |
 | KAN-19 | Feature | Ideas | Historique ventes |
-| KAN-158 | Feature | Ideas | Polish UX onboarding producteur — état Stripe restricted (KYC incomplet) |
+| KAN-158 | Feature | À faire | Polish UX onboarding producteur — état Stripe restricted (KYC incomplet) — [Cadrage tech](specs/KAN-158/) |
 | KAN-62 | Subtask | Ideas | Connecter son compte bancaire via Stripe Connect (KYC léger + IBAN) — parent KAN-16 |
 | KAN-63 | Subtask | Ideas | Renseigner ses informations de profil (nom, description, photo) — parent KAN-17 |
 | KAN-64 | Subtask | Ideas | Renseigner l'adresse exacte de la ferme ou du point de collecte — parent KAN-17 |

--- a/specs/KAN-158/design.md
+++ b/specs/KAN-158/design.md
@@ -1,0 +1,87 @@
+# Conception technique — KAN-158 Polish UX onboarding producteur — état Stripe restricted
+
+## Vue d'ensemble
+
+Trois changements coordonnés, sans nouvelle migration ni nouvel endpoint :
+
+1. **Core** : externalisation de la table de mapping i18n des requirements Stripe dans `packages/core/src/producer/stripe-requirements-i18n.ts`. Helper `translateRequirements(keys: string[])` qui retourne `Array<{ key, label_fr, fallback: boolean }>`. Refacto du use case `requestStripeOnboardingLink` pour dispatcher internement entre Account Link `account_onboarding` (si compte Stripe absent) ou `account_update` (si compte présent mais `payouts_enabled = false`). Signature publique inchangée côté endpoint pour éviter de toucher la couche HTTP.
+
+2. **UI** : nouveau composant `StripeAccountStatusCard` qui prend en input `{ status, payouts_enabled, requirements }` et rend visuellement adapté :
+   - `not_created` → card initiale « Configurer Stripe Connect » (existing `StripeOnboardingCard` réutilisé)
+   - `pending` (en cours d'onboarding initial, requirements vides) → état d'attente neutre
+   - `restricted` (details_submitted=true, requirements non vides) → card « Stripe vérifie votre compte » avec listing requirements traduits + CTA violet « Compléter mes informations »
+   - `restricted` (details_submitted=true, requirements vides) → message d'attente « Stripe valide votre compte sous 24h »
+   - `active` → DonePanel (déjà existant)
+   - `disabled` → bandeau rouge « Compte désactivé » + CTA contact support (lien `mailto:` au MVP)
+
+3. **Page** : `ProducerOnboardingClient` simplifié — la logique `phase: WizardPhase` est remplacée par un dispatch direct sur l'état producer. Pas de state local de phase quand on est sur l'étape Stripe.
+
+## Packages touchés
+
+- [ ] `packages/contracts` — pas de nouveau schema Zod (le payload de l'endpoint reste identique)
+- [x] `packages/core` — `stripe-requirements-i18n.ts` (table + helper) + refacto `request-stripe-link.ts` (dispatch onboarding/update)
+- [ ] `packages/db` — pas de changement (la table `producers` couvre déjà tous les besoins)
+- [x] `apps/web` — extension `apps/web/lib/stripe/client.ts` : `getStripeConnectAdapter` étendu avec une méthode `createAccountUpdateLink(accountId)`. Refacto `producteur-client.tsx`. Pas de nouvel endpoint.
+- [ ] `apps/mobile` — différé
+- [ ] `packages/jobs` — pas de changement
+- [ ] `supabase/migrations` — aucune migration
+- [ ] `supabase/policies` — aucun changement
+- [x] `packages/ui-web` — nouveau `StripeAccountStatusCard` (cohabite avec `StripeOnboardingCard` existant ou le subsume — à arbitrer à l'implémentation)
+
+## Modèle de données
+
+Aucun changement. Les colonnes `stripe_status`, `payouts_enabled`, `charges_enabled`, `requirements_currently_due` (KAN-16) couvrent déjà tous les besoins.
+
+## API / Endpoints
+
+`POST /api/v1/producer/onboarding/stripe-link` (existant) devient **polymorphe** selon l'état :
+
+| État producer | Comportement |
+|---|---|
+| `stripe_account_id IS NULL` | Crée le compte + Account Link `account_onboarding` (= KAN-16 inchangé) |
+| `stripe_account_id IS NOT NULL` ET `payouts_enabled = false` | Account Link `account_update` sur le compte existant, `collection_options.fields = 'currently_due'` |
+| `payouts_enabled = true` | 409 `StripeAccountAlreadyEnabledError` (= KAN-16 inchangé) |
+
+Output `{ url, expires_at }` inchangé. Codes HTTP inchangés. Rate-limit inchangé (10 / 15 min côté `producer:stripe-link:<userId>` — déjà permissif pour le re-clic après expiration Account Link).
+
+## Impact state machine / events
+
+Aucun impact mission. Pas de nouveau event Inngest. Pas de nouveau handler webhook Stripe. Le webhook `account.updated` continue à pousser les updates dans la même row (cf. KAN-16) — c'est cette synchronisation qui fait passer la card de `restricted` → `active` une fois Stripe validé.
+
+## Dépendances
+
+Référence : ARCHITECTURE.md §2. État du provisionnement : `tech/setup.md`.
+
+- **Stripe Connect Express** — voir `tech/setup.md` § Stripe Connect Express. Statut *Partiel* mais le câblage code requis (Account Links) est déjà fait par KAN-16. Pas de nouveau provisionnement.
+- **Supabase Auth + DB** — *Fait*. Pas de changement.
+- Aucune nouvelle dépendance externe.
+
+## État UI
+
+Référence : DESIGN.md ; maquette `design/maquettes/producteur/pr-02-onboarding-stripe.html`.
+
+- **Card "Stripe vérifie votre compte" — état `restricted` avec requirements** : header (icône Stripe violet + titre « Stripe vérifie votre compte » + sous-titre « Quelques informations à compléter »), bandeau orange clair listant à puces les requirements traduits (ex : « Pièce d'identité du représentant », « Adresse personnelle », « IBAN »), CTA violet « Compléter mes informations » → ouvre Account Link `account_update`, mention « Redirection sécurisée vers Stripe »
+- **Card "En attente Stripe" — `restricted` avec requirements vides** : header rassurant gris-vert (« Validation en cours »), message « Stripe finalise la vérification — généralement sous 24h », pas de CTA principal, lien « Aller à mon espace »
+- **Card "Compte désactivé" — `stripe_status = disabled`** : bandeau rouge, message « Votre compte Stripe a été désactivé. Contactez le support pour comprendre et résoudre. », bouton secondaire `mailto:support@delta.fr` (au MVP, à remplacer par un vrai canal post-Resend)
+- **États génériques** : loading sur CTA, erreurs réseau (toast neutre), erreur Stripe upstream (toast + retry CTA)
+- **Responsive** : reprend la grid existante du wizard (mobile pleine largeur, desktop confiné au panneau de droite à 640px max-width)
+
+**Conflit maquette ↔ besoin** : la maquette Figma `pr-02-onboarding-stripe.html` ne couvre que l'état initial (KAN-16). Trois nouvelles cards à concevoir « à la main » sur la base de l'existant. À acter dans `specs/KAN-158/notes.md` si Figma doit être mis à jour côté design system.
+
+## Risques techniques
+
+- **Drift entre table i18n et requirements Stripe** : Stripe peut ajouter de nouveaux noms de requirements (rare mais possible — typiquement quand ils ajoutent un pays). Fallback déjà prévu : afficher le nom anglais brut + log warn côté serveur, pour qu'on l'ajoute au fil de l'eau dans la table. Pas de crash.
+- **Account Link `account_update` — paramètre `collection_options`** : Stripe v2024 demande explicitement `collection_options.fields = 'currently_due'` pour limiter l'écran hosted aux champs en attente (sans ça, l'utilisateur peut revoir tout l'onboarding). À tester en isolé.
+- **Race avec le webhook** : si `account.updated` arrive entre le SELECT initial du Server Component et le rendu, l'utilisateur peut voir un état slightly outdated. Acceptable au MVP (l'utilisateur refresh) — à upgrader si on introduit Realtime plus tard.
+- **Tests E2E** : difficile de simuler `restricted` en Playwright sans seed DB. Plan : tests unitaires sur le mapping i18n + tests d'intégration core avec adapter mockée dans plusieurs états + tests Playwright sur le mode `restricted` via seed DB (script SQL en `apps/web/e2e/fixtures/`).
+- **Couverture i18n initiale** : couvrir au moins les ~15 keys déjà observées en test pré-KAN-158 : `individual.address.city`, `individual.address.line1`, `individual.address.postal_code`, `individual.dob.day/month/year`, `individual.first_name`, `individual.last_name`, `individual.id_number`, `individual.verification.document`, `external_account`, `tos_acceptance.date`, `tos_acceptance.ip`, `business_type`, `business_profile.url`. Évolutif.
+
+## Tests envisagés
+
+Référence : ARCHITECTURE.md §10.
+
+- Unitaire `packages/core/src/producer/stripe-requirements-i18n.test.ts` : mapping de ~15 keys connus + fallback sur requirement inconnu (retourne le nom brut, ne crash pas, log expected)
+- Unitaire `packages/core/src/producer/request-stripe-link.test.ts` (existing, étendu) : nouvelles branches « update link quand compte existe ». Mocks Stripe via l'adapter.
+- Unitaire `packages/ui-web/src/stripe-account-status-card.test.tsx` (optionnel — typiquement on saute les tests RTL au MVP, mais utile ici pour valider les 4 états)
+- Intégration : test SQL seed + Playwright sur un compte en `restricted` artificiel → vérifie que la nouvelle card s'affiche, que le clic CTA appelle bien l'endpoint, que la redirect URL est de type `account_update`
+- Test manuel en preview Vercel : reprendre le compte créé pendant le smoke test KAN-16 (en `restricted`) et valider le nouveau flow visuellement

--- a/specs/KAN-158/proposal.md
+++ b/specs/KAN-158/proposal.md
@@ -1,0 +1,38 @@
+# Cadrage — KAN-158 Polish UX onboarding producteur — état Stripe restricted
+
+## Liens
+
+- Jira : https://erkulaws.atlassian.net/browse/KAN-158
+- Epic : KAN-4 Profil Producteur
+- Parent fonctionnel : KAN-16 (Onboarding Stripe Connect) — livré sur `main` (PR #10), cadrage `specs/KAN-16/`
+- Maquette : `design/maquettes/producteur/pr-02-onboarding-stripe.html` *(pas de variante dédiée à l'état restricted dans le bundle Figma — à concevoir au fil de l'implémentation en cohérence avec l'existant ; à acter dans `notes.md` si conflit ou export Figma nécessaire)*
+- PRD : §10.2 PR-02 Onboarding Stripe Connect
+- ARCHITECTURE : §3 (monorepo), §8 (Stripe Connect — Account Links), §10 (tests), §14 (playbook)
+
+## Pourquoi (côté tech)
+
+Le smoke test de KAN-16 (2026-05-17, prod) a révélé une friction UX : quand Stripe Connect Express reste en `restricted` (KYC incomplet, ex. document d'identité du représentant manquant), notre wizard re-propose l'étape « Configurer Stripe Connect » alors que tout est déjà fait côté flow Delta. L'utilisateur ne comprend pas où il en est, ne sait pas quoi compléter, et risque d'abandonner. Cette feature ferme ce gap en différenciant les états Stripe métier (`pending` / `restricted` / `disabled` / `active`) et en proposant la bonne action selon le cas, plutôt qu'une seule card statique « Configurer Stripe Connect ».
+
+## Périmètre technique
+
+**In scope :**
+
+- Nouveau composant `StripeAccountStatusCard` (gère 4 états : initial / vérification-en-cours / restricted / disabled) dans `packages/ui-web/`
+- Table de mapping français des `requirements_currently_due` Stripe dans `packages/core/src/producer/stripe-requirements-i18n.ts` (couverture des ~15 keys observées en test + fallback gracieux pour les inconnues)
+- Refactor de l'endpoint `POST /api/v1/producer/onboarding/stripe-link` pour générer un Account Link de type `account_update` (au lieu d'`account_onboarding`) quand `producers.stripe_account_id IS NOT NULL` — endpoint inchangé côté URL, comportement polymorphe selon l'état
+- Mise à jour de `ProducerOnboardingClient` (`producteur-client.tsx`) pour brancher la nouvelle card selon le tuple (`stripe_status`, `payouts_enabled`, `requirements_currently_due`)
+- Différenciation visuelle : banner / couleur par statut (info bleue pour `pending`, orange pour `restricted` action-requise, gris pour attente passive, rouge pour `disabled`)
+
+**Out of scope (cette US) :**
+
+- Realtime / polling pour rafraîchir l'état sans reload — différé tant qu'on n'a pas Sentry pour mesurer la friction réelle, et tant qu'on n'a pas besoin de ce pattern ailleurs
+- Email / push de notif quand `payouts_enabled` passe à true — couplé à KAN-54 (push) / KAN-55 (in-app)
+- Mobile (`apps/mobile` non scaffolded)
+- Onboarding rameneur (KAN-37) — utilisera ces briques (i18n + card) mais flow distinct
+
+## Hypothèses
+
+- Les noms de requirements Stripe (`individual.address.city`, `business_profile.url`, etc.) sont stables côté API. Si Stripe en introduit de nouveaux non couverts par la table i18n, fallback gracieux : afficher le nom anglais brut sans crasher, et logger un warn côté serveur pour qu'on ajoute le mapping FR au fil de l'eau
+- Account Link `account_update` accepte les mêmes `return_url` / `refresh_url` que `account_onboarding` (vérifié côté doc Stripe : https://docs.stripe.com/api/account_links/create)
+- L'utilisateur peut re-cliquer plusieurs fois sur le CTA « Compléter mes informations » sans bug — chaque appel régénère un Account Link frais (les liens expirent en ≤ 5 min comme l'onboarding initial)
+- La maquette Figma sera enrichie *a posteriori* si nécessaire, pas un blocker pour cette US (on conçoit visuellement à la main en restant strict sur DESIGN.md)

--- a/specs/KAN-158/tasks.md
+++ b/specs/KAN-158/tasks.md
@@ -1,0 +1,32 @@
+# Tâches techniques internes — KAN-158 Polish UX onboarding producteur — état Stripe restricted
+
+> Ces tâches ne sont pas dans Jira. Setup, migrations, refacto, helpers partagés, seeds, configuration — tout ce qui n'a pas vocation à être tracké comme livrable produit.
+>
+> Subtasks Jira existantes (rappel — ne pas dupliquer ici) :
+> (aucune)
+
+## Tâches
+
+- [ ] Créer `packages/core/src/producer/stripe-requirements-i18n.ts` : table de mapping `Record<string, string>` (clé Stripe → label FR) + helper `translateRequirements(keys: string[]): Array<{ key, label, fallback }>` avec fallback gracieux pour les keys inconnues (log + retour du brut)
+- [ ] Tests unitaires `stripe-requirements-i18n.test.ts` : ~15 keys + fallback (~20 tests)
+- [ ] Étendre `apps/web/lib/stripe/client.ts` : nouvelle méthode `createAccountUpdateLink(accountId)` dans `getStripeConnectAdapter`, signature symétrique à `createAccountLink` existante mais avec `type: 'account_update'` + `collection_options: { fields: 'currently_due' }`
+- [ ] Étendre `packages/core/src/producer/adapters.ts` : ajouter `createAccountUpdateLink` à `StripeConnectAdapter` (types) — apps/web et tests devront s'adapter
+- [ ] Refacto `packages/core/src/producer/request-stripe-link.ts` : dispatcher entre `createConnectAccount + createAccountLink` (compte absent) ou `createAccountUpdateLink` (compte présent). Garder la signature publique du use case (`requestStripeOnboardingLink`) inchangée pour éviter de toucher l'endpoint.
+- [ ] Étendre les tests unitaires du use case avec les nouvelles branches
+- [ ] Créer `packages/ui-web/src/stripe-account-status-card.tsx` (composant client) : rend les 5 cas (not_created / pending / restricted-with-reqs / restricted-empty / disabled). Récupère i18n via le helper core (passé en props pour rester pur côté UI)
+- [ ] Mettre à jour `packages/ui-web/src/index.ts` : exporter `StripeAccountStatusCard` + types
+- [ ] Refacto `apps/web/app/(auth)/onboarding/producteur/producteur-client.tsx` : remplacer la logique `phase: WizardPhase` par un dispatch direct sur l'état producer (passé du Server Component) ; la `StripeAccountStatusCard` rend l'écran approprié quand on est à l'étape 3
+- [ ] Passer la fonction `initialPhase()` du client component vers le server component (`page.tsx`) ou la simplifier — la décision « quelle étape afficher » devient purement dérivée de l'état DB
+- [ ] Smoke test en preview Vercel avec un compte producteur en `restricted` (réutilisable depuis le test KAN-16)
+- [ ] Mettre à jour `produit/jira_mapping.md` : ajouter `[Cadrage tech](specs/KAN-158/)` à la cellule KAN-158 du catalogue KAN-4 et à la mention dans le mapping écran PR-02 (déjà en place via PR #13)
+
+## Notes d'implémentation
+
+- **Pas de nouvel endpoint** — on étend `/api/v1/producer/onboarding/stripe-link` qui devient polymorphe. Plus simple côté client (un seul fetch côté UI), plus simple côté core (une seule use case avec branche interne). Si plus tard on a besoin de séparer pour des raisons de rate-limit / audit, on découpera.
+- **i18n des requirements** : les keys actuellement observées dans nos tests (cf. table `stripe_webhook_events`) donnent une bonne couverture initiale. Pour les futures keys, le fallback brut + log permet de découvrir et compléter sans crasher.
+- **Stripe `account_update` link** : la doc Stripe (https://docs.stripe.com/api/account_links/create) précise que `collection_options.fields = 'currently_due'` cible directement les champs en attente plutôt que de refaire tout l'onboarding. Le `return_url` et `refresh_url` restent identiques.
+- **Pas de décision technique structurante** : feature purement UX/UI qui s'appuie sur les patterns existants. Pas d'entrée au journal §18 d'ARCHITECTURE.md prévue.
+
+## Checklist pre-merge
+
+Voir ARCHITECTURE.md §14.3 — ne pas dupliquer ici.


### PR DESCRIPTION
Cadrage technique de [KAN-158](https://erkulaws.atlassian.net/browse/KAN-158) — polish UX onboarding producteur quand Stripe Connect reste en `restricted` (KYC incomplet).

Issu du smoke test KAN-16 (2026-05-17) : quand Stripe garde le compte en `restricted` (document d'identité manquant typiquement), notre wizard re-propose la card initiale « Configurer Stripe Connect » alors que tout est déjà fait côté flow Delta. Cette US ferme le gap en différenciant 4 états Stripe métier avec la bonne action à chaque fois.

## Contenu

- `specs/KAN-158/proposal.md` — pourquoi, périmètre, hypothèses
- `specs/KAN-158/design.md` — vue d'ensemble, packages touchés, endpoint polymorphe (`account_onboarding` vs `account_update`), composant `StripeAccountStatusCard`, table i18n des requirements
- `specs/KAN-158/tasks.md` — tâches techniques internes (helpers core, refacto adapter Stripe, refacto wizard)
- `produit/jira_mapping.md` — statut KAN-158 passé en `À faire` + lien `[Cadrage tech]`

## Notes

- Aucune migration DB / aucun nouveau provisionnement externe — feature purement UX/UI
- Pas de décision technique structurante (pas d'entrée au journal §18)
- Maquette Figma manquante pour les 3 nouveaux états — à acter dans `notes.md` à l'implémentation si export Figma nécessaire
- Endpoint `/api/v1/producer/onboarding/stripe-link` devient polymorphe (dispatch onboarding/update selon état) — pas de nouvel endpoint

## Test plan

- [ ] Relire les 3 specs et valider la couverture du périmètre
- [ ] Confirmer la table i18n des requirements (~15 keys déjà observées en test KAN-16)
- [ ] Préparer `/implement KAN-158` une fois le cadrage validé

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdvmNKEngBQJBpW4Bmi7Jb)_