### PR TITLE
docs: Add KAN-17 technical specification for producer profile

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -34,8 +34,8 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | PR-05 Création / édition produit | `pr-05-edition-produit.html` | KAN-20 (Création & édition produit) | KAN-21 (Photos), KAN-22 (Stock), KAN-24 (Labels & catégories) |
 | PR-06 Récupération à venir | `pr-06-recuperation.html` | KAN-46 (QR Pickup), KAN-47 (Checklist remise producteur) | KAN-45 |
 | PR-07 Historique ventes | `pr-07-historique-ventes.html` | KAN-19 (Historique ventes) | KAN-36 (Factures PDF) |
-| PR-08 Profil public producteur | `pr-08-profil-public.html` | KAN-17 (Informations profil & ferme) | KAN-53 (Profils publics & avis), KAN-63, KAN-64, KAN-65, KAN-66 |
-| PR-09 Paramètres compte | `pr-09-parametres.html` | KAN-17 (Informations profil & ferme) | — |
+| PR-08 Profil public producteur | `pr-08-profil-public.html` | KAN-17 (Informations profil & ferme) — [Cadrage tech](specs/KAN-17/) | KAN-53 (Profils publics & avis), KAN-63, KAN-64, KAN-65, KAN-66 |
+| PR-09 Paramètres compte | `pr-09-parametres.html` | KAN-17 (Informations profil & ferme) — [Cadrage tech](specs/KAN-17/) | — |
 
 ### Parcours Acheteur (§10.3 PRD)
 
@@ -102,7 +102,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 |--------|------|--------|--------|
 | KAN-4 | Epic | Ideas | Profil Producteur |
 | KAN-16 | Feature | Terminé | Onboarding Stripe Connect — [Cadrage tech](specs/KAN-16/) — mergé sur main (PR #10) |
-| KAN-17 | Feature | Ideas | Informations profil & ferme |
+| KAN-17 | Feature | À faire | Informations profil & ferme — [Cadrage tech](specs/KAN-17/) |
 | KAN-18 | Feature | Ideas | Tableau de bord producteur |
 | KAN-19 | Feature | Ideas | Historique ventes |
 | KAN-158 | Feature | Terminé | Polish UX onboarding producteur — état Stripe restricted (KYC incomplet) — [Cadrage tech](specs/KAN-158/) — mergé sur main (PR #15) |

--- a/specs/KAN-17/design.md
+++ b/specs/KAN-17/design.md
@@ -1,0 +1,130 @@
+# Conception technique — KAN-17 Informations profil & ferme
+
+## Vue d'ensemble
+
+Extension verticale de la table `producers` (créée par KAN-16) avec les champs publics (identité, photos, adresse, créneaux) et un volet exploitation (`paused`). Un seul endpoint `PATCH /api/v1/producer/profile` orchestre l'édition partielle, validé par Zod. Les uploads de photos passent par un endpoint signé qui pousse vers le bucket Storage `producer-photos`. Le formulaire est un composant unique (`<ProducerProfileForm />`) consommé à la fois par l'étape 1 du wizard `/onboarding/producer` et par la page autonome `/producer/profile`.
+
+La sensibilité de l'adresse exacte (révélée seulement aux rameneurs en mission validée) est exprimée par une **RLS row-level + colonne masquée par une vue applicative** plutôt que par une RLS colonne (Postgres ne supporte pas le column-level RLS directement). Concrètement : la colonne `pickup_address` (texte exact) est lisible uniquement par le owner et le service_role ; les rameneurs y accèdent via une `SECURITY DEFINER` function `reveal_pickup_address(producer_id)` qui vérifie l'existence d'une mission en cours sur ce producteur pour le caller. Les acheteurs ne voient que `pickup_public_zone`.
+
+## Packages touchés
+
+- [x] `packages/contracts` — schémas Zod (`producerProfileSchema`, `pickupAddressSchema`, `farmPhotosSchema`)
+- [x] `packages/core` — règles métier (validation labels enum, vérification taille photos, normalisation horaires)
+- [x] `packages/db` — repo `producers` (ajout `findById`, `updateProfile`, `setPaused`), helper RPC `revealPickupAddress`
+- [x] `apps/web` — page `/producer/profile`, intégration dans `/onboarding/producer` step 1, route handlers `app/api/v1/producer/profile/route.ts` + `app/api/v1/producer/photos/route.ts`
+- [ ] `apps/mobile` — hors scope
+- [ ] `packages/jobs` — aucun job nécessaire
+- [x] `supabase/migrations` — extension colonnes `producers` + bucket `producer-photos` + RPC `reveal_pickup_address`
+- [x] `supabase/policies` — RLS sur nouvelles colonnes (toujours via row-level), policy bucket Storage
+- [ ] `packages/ui-web` — composant `<ProducerProfileForm />` placé directement dans `apps/web/components/producer/` au MVP (pas de réutilisation cross-app prévue)
+
+## Modèle de données
+
+Ajout sur la table `producers` (un seul commit de migration). Tous les champs nullable au début, remplis progressivement par le wizard puis l'édition libre.
+
+| Colonne | Type | Note |
+|---|---|---|
+| `display_name` | `text` | Nom commercial (≤ 80 caractères, requis pour publication produits) |
+| `public_description` | `text` | Description publique (≤ 500 caractères) |
+| `profile_photo_url` | `text` | URL Supabase Storage du logo (bucket `producer-photos`) |
+| `farm_photos` | `jsonb` | Array ordonné de `{ url, alt? }`, max 3 entries (CHECK en DB) |
+| `labels` | `producer_label[]` | ENUM array — voir ci-dessous |
+| `pickup_public_zone` | `text` | Libellé commune + département (ex « Bocage normand · Évreux (27) ») |
+| `pickup_address` | `text` | Adresse exacte (sensible, RLS-protégée) |
+| `pickup_location` | `geography(Point, 4326)` | Coordonnées issues de l'API Adresse, GIST pour future utilisation matching |
+| `pickup_days` | `weekday[]` | ENUM array (mon, tue, …, sun) |
+| `pickup_hours_start` | `time` | Heure d'ouverture créneau |
+| `pickup_hours_end` | `time` | Heure de fermeture créneau (CHECK `end > start`) |
+| `paused` | `boolean NOT NULL DEFAULT false` | Boutique en pause, gating produits |
+| `paused_at` | `timestamptz` | Set quand `paused` passe à `true`, null sinon |
+
+Nouveaux ENUM :
+
+- `producer_label` : `'bio_ab' | 'demeter' | 'nature_et_progres' | 'hve_3' | 'producteur_fermier'`
+- `weekday` : `'mon'|'tue'|'wed'|'thu'|'fri'|'sat'|'sun'`
+
+RLS sur `producers` (mise à jour) :
+- `select` : owner (déjà en place via KAN-16) + lecture publique restreinte aux colonnes non-sensibles via vue/policy ; *à finaliser*, voir RPC ci-dessous.
+- `update` : owner uniquement sur ses propres colonnes ; `pickup_location` recalculée serveur, jamais en input client.
+
+RPC `reveal_pickup_address(producer_id uuid) returns text` :
+- SECURITY DEFINER, search_path = public
+- Retourne `pickup_address` si :
+  - `auth.uid()` est owner du producteur, OU
+  - il existe une mission `confirmed | picked_up` ou `delivered` rattachée à `producer_id` dont le `trip` appartient à `auth.uid()` (rameneur)
+- Sinon : null.
+
+Storage : bucket `producer-photos`, public, 5 MB, MIME `image/jpeg|image/png|image/webp`. Policy d'upload restreinte à `auth.uid() = path[0]` (chemin convention `{producer_user_id}/logo.<ext>` et `{producer_user_id}/farm-<n>.<ext>`).
+
+Référence : ARCHITECTURE.md §5.
+
+## API / Endpoints
+
+Versionnés `/api/v1/`, validés par Zod, handlers de 15-30 lignes max (cf. ARCHITECTURE.md §3, §14.2).
+
+- `GET /api/v1/producer/profile` → renvoie le profil du producteur connecté, **incluant** `pickup_address` (owner).
+- `PATCH /api/v1/producer/profile` → patch partiel. Input Zod `producerProfileUpdateSchema` (tous les champs optionnels, contraintes alignées sur la DB). Recalcule `pickup_location` serveur si `pickup_address` change (appel API Adresse).
+- `POST /api/v1/producer/photos` → upload signé. Input `{ kind: 'logo' | 'farm', slot?: 0|1|2, contentType }`. Renvoie URL signée Supabase Storage. Le client upload puis appelle `PATCH /producer/profile` avec l'URL définitive.
+- `DELETE /api/v1/producer/photos` → suppression d'un slot (logo ou farm[n]).
+- `POST /api/v1/producer/pause` → body `{ paused: boolean }`. Endpoint séparé pour limiter la portée du PATCH et faciliter l'audit.
+
+Erreurs typées (ARCHITECTURE.md §4.3) : `PROFILE_NOT_FOUND`, `INVALID_LABELS`, `ADDRESS_GEOCODE_FAILED`, `PHOTO_LIMIT_REACHED`, `UNAUTHORIZED`.
+
+Pour la révélation côté rameneur : pas d'endpoint dédié dans KAN-17 (la lecture passera par l'écran mission rameneur, KAN-43/45). On expose juste la RPC SQL `reveal_pickup_address`, consommée plus tard.
+
+## Impact state machine / events
+
+Aucun. Pas de transition mission impactée. Le toggle `paused` n'émet pas d'event Inngest (au MVP — la liste catalogue se filtre par RLS, pas par cache à invalider).
+
+## Dépendances
+
+Services externes :
+- **API Adresse Gouv.fr** — `tech/setup.md` § APIs externes ligne 203-206. Statut : Fait. Pas de clé, pas de quota documenté, cache 24 h serveur recommandé pour les requêtes répétées (peu probable ici, l'autocomplétion est rare et idempotente).
+- **Supabase Storage** — `tech/setup.md` § Supabase ligne 25 (bucket `product-photos` existe déjà comme template ; nouveau bucket `producer-photos` créé par migration).
+- **API Sirene INSEE** — non utilisée ici (KAN-16). Le chip « SIRET vérifié » sur le profil est dérivé du `siret_status` déjà présent.
+
+Internes :
+- Table `producers` (KAN-16) — étendue.
+- RLS sur `products` (KAN-16) — condition `producer.paused = false` ajoutée à la clause `published`.
+
+## État UI
+
+Référence : DESIGN.md (tokens, breakpoints).
+
+- Page `/producer/profile` : layout split 2 colonnes desktop (édition + preview sticky, breakpoint < 1080 px → mono-colonne). Sidebar producteur (cf. PR-03 dashboard) à gauche.
+- Composant `<ProducerProfileForm />` : sections "Identité de la ferme", "Photos de la ferme", "Zone & adresse de récupération". Bouton « Enregistrer » sticky, qui appelle `PATCH` (debounce 800 ms sur les champs textuels pour autosave optimiste, voir notes ARCHITECTURE.md §3 sur autosave).
+- Toggle "Boutique en pause" sur PR-09 — page `/producer/settings`. **Cette page est multi-tickets** ; au MVP la skeleton est posée mais seul le toggle pause est câblé (les autres rangs sont visuels, étiquetés « Bientôt »).
+- Composant preview `<ProducerPublicCardPreview />` : rendu pur du panel droit de PR-08, partagé avec AC-08bis plus tard (KAN-53).
+- Photo uploader : drag-drop + bouton « Changer » / « Supprimer ». Validation client-side (MIME + taille) avant signature.
+- Autocomplétion adresse : `<AddressAutocomplete />` consomme l'API Adresse Gouv.fr directement (pas de proxy serveur), pose les coordonnées dans un input hidden envoyé au PATCH.
+- Mobile : non livré, mais le formulaire est mobile-friendly (single-column < 1080 px) — décision « responsive obligatoire » respectée pour la version web.
+
+## Risques techniques
+
+- **Adresse exacte sensible** : le défaut RLS-row-level seul ne suffit pas. La RPC `reveal_pickup_address` + filtrage applicatif côté `GET /producer/profile` doivent être implémentés ensemble — sinon fuite via PostgREST direct. À tester explicitement (test négatif acheteur + test positif rameneur en mission).
+- **Storage public + RLS** : le bucket est public en lecture (logos visibles dans le catalogue), mais l'upload est restreint à `auth.uid()`. Vérifier les policies Storage versionnées dans `supabase/policies/storage.sql` (principe A7).
+- **Photos orphelines** : si l'utilisateur upload une photo puis n'enregistre pas, le fichier reste dans Storage. Au MVP on accepte la dette (volume négligeable) ; documenter pour un éventuel job cleanup post-MVP.
+- **Géocodage API Adresse** : si l'API tombe ou retourne un score < 0.5, ne pas écrire de `pickup_location` mais accepter quand même `pickup_address` (texte). Le matching dégradera proprement en attendant la prochaine édition.
+- **PostGIS** : la colonne `pickup_location` doit utiliser le type `geography` (sphérique, mètres) et non `geometry` (cartésien, degrés) pour cohérence avec `trips.route_geom` (ARCHITECTURE.md §5.4 mention `GIST (location)` sur `producers`).
+- **Migration RLS** : la migration touche RLS sur `producers` (KAN-16) et `products` (KAN-16/20). Risque de régression — tests RLS automatisés (cf. supabase-postgres-best-practices) obligatoires sur les 3 personae × 3 niveaux d'autorisation.
+- **Bundle web** : le composant preview embarque potentiellement les icônes label (5 SVG). Vérifier qu'on reste sous la cible bundle pour `/producer/profile` (ARCHITECTURE.md §11/§13).
+
+## Tests envisagés
+
+Référence : ARCHITECTURE.md §10.
+
+- **Unit `packages/core`** :
+  - Validation `producerProfileUpdateSchema` (limites taille, enum labels, format horaire, max 3 photos).
+  - Normalisation adresse (geocoding off-path : on injecte un faux résultat API Adresse et on vérifie la pose des coordonnées).
+  - Vérification logique pause → invisibilité produits (test en isolation de la fonction de gating).
+- **Intégration DB** (vitest + supabase local) :
+  - RLS `producers.update` : un user ne peut modifier que sa propre row.
+  - RLS sur lecture `pickup_address` : acheteur ne lit pas, rameneur en mission `confirmed` lit, rameneur sans mission ne lit pas.
+  - RPC `reveal_pickup_address` couvre les 3 cas (owner, rameneur autorisé, étranger).
+  - CHECK constraints DB (max 3 farm photos, horaires cohérents).
+- **E2E web Playwright** (`apps/web/e2e/producer-profile.spec.ts`) :
+  - Producteur ouvre `/producer/profile`, modifie nom + description + ajoute logo + adresse, enregistre, recharge, voit la version persistée.
+  - Onboarding step 1 : depuis `/onboarding/producer`, saisie nom + description + zone permet de passer à l'étape SIRET (KAN-16).
+  - Toggle « Boutique en pause » : sur catalogue acheteur, le producteur disparaît.
+  - Vérif adresse privée : un compte acheteur de test n'a pas accès à `pickup_address` via l'API publique.
+- **Storage** : tests Vitest sur l'endpoint d'upload (signature OK, MIME refusé, slot ≤ 2 pour farm photos).

--- a/specs/KAN-17/proposal.md
+++ b/specs/KAN-17/proposal.md
@@ -1,0 +1,54 @@
+# Cadrage — KAN-17 Informations profil & ferme
+
+## Liens
+
+- Jira : https://erkulaws.atlassian.net/browse/KAN-17
+- Epic : KAN-4 Profil Producteur
+- Maquettes :
+  - `design/maquettes/producteur/pr-08-profil-public.html` (édition + preview vue acheteur)
+  - `design/maquettes/producteur/pr-09-parametres.html` (uniquement les sections producteur — pause boutique)
+  - `design/maquettes/producteur/pr-02-onboarding-stripe.html` (étape 1 « Profil ferme », déférée depuis KAN-16)
+- PRD : §10.2 PR-08 Profil public producteur (+ §10.2 PR-02 étape 1, §10.2 PR-09)
+- ARCHITECTURE : §3 (monorepo + Storage), §5 (DB — extension table `producers`), §9 (RLS, données sensibles : adresse exacte), §10 (tests), §14 (playbook)
+
+## Pourquoi (côté tech)
+
+Le `producers` row créé par KAN-16 ne contient aujourd'hui que les volets vérifications (SIRET) et paiement (Stripe Connect). KAN-17 ajoute la **couche publique** qui rend une ferme visible et désirable côté acheteur : nom commercial, description, logo, photos d'ambiance, labels/certifications, zone publique de provenance, adresse exacte du point de récupération, créneaux. C'est aussi la première feature qui introduit :
+
+- des **uploads d'images utilisateur** (logo + galerie ferme) → Supabase Storage `producer-photos`,
+- une **donnée à visibilité asymétrique** (adresse exacte privée, révélée uniquement aux rameneurs ayant réservé une mission validée par paiement acheteur — cf. décisions produit),
+- une intégration **API Adresse Gouv.fr** pour l'autocomplétion d'adresse (décision 2026-05-01),
+- la notion de **boutique en pause** (toggle PR-09) qui masque les produits sans toucher leur statut.
+
+KAN-17 finalise l'onboarding producteur (étape 1 du wizard `/onboarding/producer`) et fournit l'écran d'édition standalone (`/producer/profile`) réutilisé ensuite tout au long de la vie du compte.
+
+## Périmètre technique
+
+**In scope :**
+
+- Étape 1 « Profil ferme » du wizard `/onboarding/producer` (orchestrée avec KAN-16) : saisie nom, description, logo, zone publique. Persistance progressive sur `producers`.
+- Page `/producer/profile` (split édition + preview, cf. PR-08) accessible depuis la sidebar producteur, identique en wizard initial et en édition ultérieure (même composant, même endpoint, même validation).
+- Édition des champs publics : `display_name`, `public_description` (500 c. max), `profile_photo_url` (logo), `labels` (chips multi-select sur enum), `farm_photos` (0 à 3, ordre stable).
+- Édition adresse de récupération : `pickup_address` (adresse exacte), `pickup_public_zone` (libellé commune + département), `pickup_days` (multi-select Lun/Mar/.../Dim), `pickup_hours_start` + `pickup_hours_end`. Autocomplétion via API Adresse Gouv.fr.
+- Endpoint `GET /api/v1/producer/profile` (self) + `PATCH /api/v1/producer/profile` (partial update, Zod).
+- Upload photos : route `POST /api/v1/producer/photos` (logo et galerie) qui signe l'upload Supabase Storage et persiste l'URL sur `producers`. Suppression d'une photo réinitialise le slot.
+- Toggle « Boutique en pause » (PR-09) : booléen `paused` sur `producers`. Tant que `true`, les produits ne sont plus visibles côté catalogue acheteur (gating exprimé par RLS sur `products`, étend la condition existante de KAN-16).
+- RLS adresse exacte (`pickup_address`) : la colonne reste lisible par le producteur lui-même, par le service_role, et par les rameneurs ayant une mission `confirmed`/`picked_up`/`delivered` sur ce producteur. Non lisible par les acheteurs, jamais. (Détail : `design.md`.)
+- Vue publique préfigurée dans la preview (PR-08, panel droit) : composant partagé qui sera réutilisé par AC-08bis (KAN-53). Pas de route publique livrée ici — c'est de la preview client-side à partir des données du PATCH.
+
+**Out of scope (cette US) :**
+
+- Page publique acheteur AC-08bis (`/p/[producer-id]`) et avis publics → **KAN-53** (Profils publics & avis).
+- Sections non-producteur de PR-09 (changement email/mot de passe → KAN-3, notifications → KAN-14, RGPD export/suppression → backlog, multi-rôle → KAN-37 / KAN-25).
+- Mobile (`apps/mobile/`) — non scaffold, différé global.
+- Refonte du processus de modification email/SIRET — couvert par KAN-3 / KAN-16.
+- Image processing serveur (resize, watermark, optimisation WebP) — au MVP on accepte JPG/PNG/WebP tel quel, taille max 5 MB (config bucket).
+
+## Hypothèses
+
+- Le bucket `product-photos` (KAN-20) n'existe pas encore (Storage seulement provisionné dans `tech/setup.md`). On crée ici un bucket dédié `producer-photos` (public, 5 MB, MIME jpeg/png/webp) — cohérent avec le bucket `product-photos` du setup, mais séparé pour permettre des policies indépendantes.
+- L'API Adresse Gouv.fr (déjà provisionnée, sans clé) est utilisée directement depuis le client pour l'autocomplétion. Les coordonnées (lat/lng) retournées sont stockées en colonne `pickup_location geography(Point, 4326)` (PostGIS) pour servir plus tard au matching (KAN-42) — défense en avance, pas de logique active dans KAN-17.
+- Les labels/certifications sont un **enum fermé** au MVP (`Bio AB`, `Demeter`, `Nature & Progrès`, `HVE niveau 3`, `Producteur fermier`). « SIRET vérifié » est un chip dérivé de `siret_status = 'verified'`, pas un label éditable.
+- L'étape 1 du wizard KAN-16 est intentionnellement vide aujourd'hui (placeholder « Profil ferme »). KAN-17 la remplit en réutilisant le même composant que la page `/producer/profile` (un seul formulaire, deux contextes).
+- La preview vue acheteur est rendue 100 % côté client (pas d'aller-retour serveur) à partir du state du formulaire — pas de route publique nécessaire.
+- Pas de notif quand un producteur édite son profil. Édition silencieuse, sans audit trail à ce stade (le row `producers` a un `updated_at` qui suffit).

--- a/specs/KAN-17/tasks.md
+++ b/specs/KAN-17/tasks.md
@@ -1,0 +1,43 @@
+# Tâches techniques internes — KAN-17 Informations profil & ferme
+
+> Ces tâches ne sont pas dans Jira. Setup, migrations, refacto, helpers partagés, seeds, configuration — tout ce qui n'a pas vocation à être tracké comme livrable produit.
+>
+> Subtasks Jira existantes (rappel — ne pas dupliquer ici) :
+> - KAN-63 — Renseigner ses informations de profil (nom, description, photo)
+> - KAN-64 — Renseigner l'adresse exacte de la ferme ou du point de collecte
+> - KAN-65 — Modifier ses informations de profil
+> - KAN-66 — Visualiser son profil public (vue acheteur / rameneur)
+
+## Tâches
+
+- [ ] Migration `supabase/migrations/YYYYMMDDHHMMSS_extend_producers_profile.sql` :
+  - Création des ENUM `producer_label`, `weekday`
+  - Ajout des colonnes profil + adresse + créneaux + `paused`
+  - Création de la colonne `pickup_location geography(Point, 4326)` + index GIST
+  - CHECK constraints (max 3 farm photos, horaires cohérents, longueurs textes)
+  - RPC `reveal_pickup_address(producer_id uuid)` SECURITY DEFINER
+  - Mise à jour RLS `producers` (insert/update owner-only sur les nouvelles colonnes)
+  - Mise à jour RLS `products` (étendre gating `published` avec `producer.paused = false`)
+- [ ] Migration bucket Storage `producer-photos` :
+  - Création bucket via `storage.buckets` insert (config 5 MB, MIME jpeg/png/webp, public)
+  - Policies dans `supabase/policies/storage.sql` (upload owner-only, lecture publique)
+- [ ] Helper `packages/db/src/producers/repo.ts` — méthodes `findById`, `findByUserId`, `updateProfile(partial)`, `setPaused(bool)`, `revealPickupAddress(producerId)` (wrap RPC)
+- [ ] Helper `apps/web/lib/storage/producer-photos.ts` — signature upload, suppression, helper chemin canonique
+- [ ] Helper `apps/web/lib/geocoding/adresse-gouv.ts` — wrapper API Adresse Gouv.fr (search + get coordinates) + cache mémoire 24 h
+- [ ] Schemas Zod `packages/contracts/src/producer-profile.ts` — `producerProfileSchema`, `producerProfileUpdateSchema`, `pickupAddressSchema`, `farmPhotosSchema`, `labels` (z.enum)
+- [ ] Export depuis `packages/contracts/src/index.ts`
+- [ ] Composant `apps/web/components/producer/ProducerProfileForm.tsx` (form unique, props `mode: 'wizard' | 'edit'`)
+- [ ] Composant `apps/web/components/producer/ProducerPublicCardPreview.tsx` (rendu pur, prêt pour réutilisation KAN-53)
+- [ ] Composant `apps/web/components/forms/AddressAutocomplete.tsx` (réutilisable — sera repris par KAN-25 acheteur, KAN-41 rameneur)
+- [ ] Composant `apps/web/components/producer/PhotoUploader.tsx` (avatar + galerie)
+- [ ] Page `apps/web/app/producer/profile/page.tsx` (mode édition)
+- [ ] Intégration dans `apps/web/app/onboarding/producer/page.tsx` (mode wizard step 1, remplace le placeholder de KAN-16)
+- [ ] Skeleton page `apps/web/app/producer/settings/page.tsx` avec le toggle pause câblé + les autres sections en placeholder « Bientôt » (à supprimer / compléter au fil des tickets KAN-3 / KAN-14)
+- [ ] Tests unitaires `packages/core/src/producer/profile.test.ts`
+- [ ] Tests intégration RLS `supabase/tests/producers-rls.sql` (ou vitest avec supabase local — convention à valider, voir notes KAN-3)
+- [ ] Tests E2E Playwright `apps/web/e2e/producer-profile.spec.ts`
+- [ ] Seed dev `supabase/seeds/producer-profile-sample.sql` (un producteur démo avec profil rempli — utile pour KAN-53 / catalogue acheteur)
+
+## Checklist pre-merge
+
+Voir ARCHITECTURE.md §14.3 — ne pas dupliquer ici.


### PR DESCRIPTION
## Summary

Add comprehensive technical specification documents for KAN-17 (Producer Profile & Farm Information), establishing the design, scope, and implementation roadmap for the producer profile feature.

## Changes

- **`specs/KAN-17/design.md`** — Technical design document covering:
  - Data model extension to `producers` table (display_name, public_description, profile_photo_url, farm_photos, labels, pickup address/zone/location, pickup days/hours, paused status)
  - Two new PostgreSQL ENUMs: `producer_label` and `weekday`
  - RLS strategy for sensitive `pickup_address` column using row-level security + SECURITY DEFINER RPC `reveal_pickup_address()` to asymmetrically expose address only to owner and authorized rameneurs
  - Storage bucket `producer-photos` configuration (5 MB, public read, owner-only upload)
  - API endpoints: `GET/PATCH /api/v1/producer/profile`, `POST/DELETE /api/v1/producer/photos`, `POST /api/v1/producer/pause`
  - UI components and pages: `ProducerProfileForm`, `ProducerPublicCardPreview`, `/producer/profile`, `/producer/settings`
  - Risk analysis (address privacy, orphaned photos, geocoding failures, PostGIS type selection, RLS regression testing)
  - Test strategy (unit, integration RLS, E2E Playwright, Storage)

- **`specs/KAN-17/proposal.md`** — Scope and rationale document covering:
  - Links to Jira, maquettes, PRD sections, and architecture references
  - Why this feature (public layer for producer visibility, first image uploads, asymmetric data visibility, API Adresse integration, pause toggle)
  - In-scope deliverables (onboarding step 1, profile page, public fields, address with geocoding, photo uploads, pause toggle, RLS for address, public preview component)
  - Out-of-scope items (public profile page AC-08bis → KAN-53, mobile, email/SIRET changes, image processing)
  - Key assumptions (separate `producer-photos` bucket, API Adresse direct from client, closed enum labels, single form component reused in wizard and edit modes, client-side preview)

- **`specs/KAN-17/tasks.md`** — Internal task checklist (non-Jira) covering:
  - Database migration (ENUMs, columns, constraints, RPC, RLS updates, bucket creation)
  - Helper functions (repo methods, Storage signing, geocoding wrapper, Zod schemas)
  - React components (form, preview, address autocomplete, photo uploader)
  - Pages and integrations (profile page, onboarding integration, settings skeleton)
  - Tests (unit, RLS integration, E2E, seed data)
  - Pre-merge checklist reference

- **`produit/jira_mapping.md`** — Updated mapping table to link PR-08 and PR-09 maquettes to KAN-17 with reference to new `specs/KAN-17/` documentation

## Implementation Notes

- The address privacy mechanism uses a hybrid approach: row-level RLS for baseline protection + a SECURITY DEFINER function to selectively reveal `pickup_address` to rameneurs with confirmed/picked_up/delivered missions, avoiding direct column-level RLS (not supported by PostgreSQL)
- Photos are uploaded via signed URLs to Supabase Storage, with URLs persisted in the `farm_photos` JSONB array (max 3 entries enforced by CHECK constraint)
- The same `ProducerProfileForm` component serves both the onboarding wizard (step 1) and the standalone edit page (`/producer/profile`), reducing duplication
- Geocoding via API Adresse Gouv.fr is called client-side for autocompletion; server recalculates `pickup_location` on PATCH if address changes
- The `paused` toggle gates product visibility via RLS on `products` table (extends existing `published` condition from KAN-16)

https://claude.ai/code/session_016uEKKRk9pdLyDHStMUMKzK