### PR TITLE
Mapping Jira : KAN-17 en Terminé (merge PR #18)

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -9,7 +9,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 - **13 épics** (KAN-1, KAN-4 → KAN-15) — un épic par grand domaine fonctionnel
 - **50 features cataloguées** (KAN-2, KAN-3 sous KAN-1 ; KAN-16 → KAN-158 sous les autres épics — voir tables par épic ci-dessous)
 - **Subtasks** : voir le catalogue par épic ci-dessous. Le mapping peut être incomplet pour les subtasks les plus récentes — Jira fait foi pour la liste exhaustive.
-- État au 2026-05-17 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; autres *Ideas*
+- État au 2026-05-17 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-17 *Terminé* (mergé sur `main` — PR #18, cadrage `specs/KAN-17/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; autres *Ideas*
 - **Maquettes (2026-05-14)** : les 35 écrans des 3 parcours (Producteur, Acheteur, Rameneur) du sitemap PRD §10 sont maquettés. Restent à maquetter : transverses **TR-02** (centre notifications) et **TR-04** (signalement / litige) ; **TR-03** est couvert par `rm-09-chat.html`. Index navigable de toutes les maquettes : `design/maquettes/index.html`
 
 ## Convention de référencement
@@ -102,7 +102,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 |--------|------|--------|--------|
 | KAN-4 | Epic | Ideas | Profil Producteur |
 | KAN-16 | Feature | Terminé | Onboarding Stripe Connect — [Cadrage tech](specs/KAN-16/) — mergé sur main (PR #10) |
-| KAN-17 | Feature | Wip | Informations profil & ferme — [Cadrage tech](specs/KAN-17/) |
+| KAN-17 | Feature | Terminé | Informations profil & ferme — [Cadrage tech](specs/KAN-17/) — mergé sur main (PR #18) |
 | KAN-18 | Feature | Ideas | Tableau de bord producteur |
 | KAN-19 | Feature | Ideas | Historique ventes |
 | KAN-158 | Feature | Terminé | Polish UX onboarding producteur — état Stripe restricted (KYC incomplet) — [Cadrage tech](specs/KAN-158/) — mergé sur main (PR #15) |


### PR DESCRIPTION
## Summary

KAN-17 « Informations profil & ferme producteur » a été mergée sur `main` via PR #18. Cette PR aligne `produit/jira_mapping.md` sur l'état Jira (`Wip` → `Terminé`) et le ticket Jira KAN-17 a été transitionné en parallèle via MCP.

Conforme au workflow `CLAUDE.md` § « Après merge d'une feature sur `main` ».

## Test plan

- [ ] Aucune CI métier — diff doc-only

## Note épic parent KAN-4 (Profil Producteur)

État après ce merge :
- KAN-16 Onboarding Stripe Connect → **Terminé** (PR #10)
- KAN-17 Informations profil & ferme → **Terminé** (PR #18, présent)
- KAN-158 Polish UX onboarding restricted → **Terminé** (PR #15)
- KAN-18 Tableau de bord producteur → *Ideas*
- KAN-19 Historique ventes → *Ideas*

L'épic KAN-4 reste ouvert (deux features encore à venir). Pas de clôture automatique.

https://claude.ai/code/session_016uEKKRk9pdLyDHStMUMKzK

---
_Generated by [Claude Code](https://claude.ai/code/session_016uEKKRk9pdLyDHStMUMKzK)_