### PR TITLE
docs: Add KAN-18 technical specification for producer dashboard

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -29,7 +29,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 |-------|----------|-------------------------------|--------------|
 | PR-01 Inscription / connexion | `pr-01-authentication.html` | KAN-2 (Création de compte), KAN-3 (Connexion), KAN-157 (Récup. mot de passe) | [Cadrage KAN-2](specs/KAN-2/), [Cadrage KAN-3](specs/KAN-3/), [Cadrage KAN-157](specs/KAN-157/) |
 | PR-02 Onboarding Stripe Connect | `pr-02-onboarding-stripe.html` | KAN-16 (Onboarding Stripe Connect) — [Cadrage tech](specs/KAN-16/) | KAN-62, KAN-158 (polish UX restricted) |
-| PR-03 Dashboard | `pr-03-dashboard.html` | KAN-18 (Tableau de bord producteur) | KAN-56 |
+| PR-03 Dashboard | `pr-03-dashboard.html` | KAN-18 (Tableau de bord producteur) — [Cadrage tech](specs/KAN-18/) | KAN-56 |
 | PR-04 Catalogue produits | `pr-04-catalogue.html` | KAN-20 (Création & édition produit) | KAN-23 (Statuts produit) |
 | PR-05 Création / édition produit | `pr-05-edition-produit.html` | KAN-20 (Création & édition produit) | KAN-21 (Photos), KAN-22 (Stock), KAN-24 (Labels & catégories) |
 | PR-06 Récupération à venir | `pr-06-recuperation.html` | KAN-46 (QR Pickup), KAN-47 (Checklist remise producteur) | KAN-45 |
@@ -103,7 +103,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | KAN-4 | Epic | Ideas | Profil Producteur |
 | KAN-16 | Feature | Terminé | Onboarding Stripe Connect — [Cadrage tech](specs/KAN-16/) — mergé sur main (PR #10) |
 | KAN-17 | Feature | Terminé | Informations profil & ferme — [Cadrage tech](specs/KAN-17/) — mergé sur main (PR #18) |
-| KAN-18 | Feature | Ideas | Tableau de bord producteur |
+| KAN-18 | Feature | À faire | Tableau de bord producteur — [Cadrage tech](specs/KAN-18/) |
 | KAN-19 | Feature | Ideas | Historique ventes |
 | KAN-158 | Feature | Terminé | Polish UX onboarding producteur — état Stripe restricted (KYC incomplet) — [Cadrage tech](specs/KAN-158/) — mergé sur main (PR #15) |
 | KAN-62 | Subtask | Ideas | Connecter son compte bancaire via Stripe Connect (KYC léger + IBAN) — parent KAN-16 |

--- a/specs/KAN-18/design.md
+++ b/specs/KAN-18/design.md
@@ -1,0 +1,107 @@
+# Conception technique — KAN-18 Tableau de bord producteur
+
+## Vue d'ensemble
+
+KAN-18 livre l'enveloppe applicative de l'espace producteur web : un layout Next factorisé (`apps/web/app/producer/layout.tsx`) qui charge une seule fois la session + la row `producers` du caller, gère le gating par rôle (redirect vers l'espace correspondant si l'utilisateur n'est pas producteur), et un dashboard (`/producer/page.tsx`) composé de sections câblées sur ce qui existe (`siret_status`, `stripe_status`, `paused`, `display_name`, `first_name`) et de sections en **empty state** pour tout ce qui dépend de tables non livrées. Aucun nouveau endpoint, aucune migration DB. L'enjeu architectural : poser le **pattern sidebar + layout authentifié multi-pages** réutilisé ensuite par AC-* et RM-*, sans coupler le code à un rôle particulier.
+
+## Packages touchés
+
+- [ ] `packages/contracts` — aucun schéma Zod nouveau
+- [ ] `packages/core` — aucun use case nouveau
+- [ ] `packages/db` — possible ajout d'un helper `getProducerDashboardContext(userId)` qui regroupe `users.findById` + `producers.findByUserId` en une seule lecture si on observe une duplication ; sinon, on appelle les deux repos existants côte à côte avec React `cache()`
+- [x] `apps/web` — layout `producer/layout.tsx`, page `producer/page.tsx`, composants sidebar / topbar / banners / dashboard, refactor profile/settings, helper navigation
+- [ ] `apps/mobile` — hors scope
+- [ ] `packages/jobs` — aucun
+- [ ] `supabase/migrations` — aucune
+- [ ] `supabase/policies` — aucune
+- [ ] `packages/ui-web` — composants restent dans `apps/web/components/` au MVP — pas de réutilisation cross-app prévue immédiatement, migration vers `packages/ui-web/` quand AC-* en aura besoin (cf. décision KAN-17 sur la même logique)
+
+## Modèle de données
+
+Aucune extension. Tables lues (toutes existantes) :
+
+- `users` — `first_name`, `roles`, `id`
+- `producers` — `display_name`, `siret_status`, `siret_status_reason` (si rejected), `stripe_status`, `paused`, `created_at`
+
+Les sections « empty state » seront câblées plus tard sur :
+- `products` (KAN-20) → KPI « Produits actifs », section « Stock à surveiller »
+- `missions` + `mission_buyers` (KAN-10) → KPIs « Commandes en cours », sections « Prochaines récupérations » et « Ventes en cours »
+- `mission_events` filtrés (KAN-11) → section « Activité récente »
+- Trace des transferts Stripe (à introduire avec la première mission `delivered`) → KPI « Revenus du mois » et section « Prochain virement Stripe »
+- `reviews` (KAN-53) → KPI « Note moyenne »
+
+Référence : ARCHITECTURE.md §5.3.
+
+## API / Endpoints
+
+Aucun nouveau endpoint. Le layout est server-side et lit via les repos `packages/db/users` et `packages/db/producers` directement. Pas de route handler.
+
+Si à terme on veut un endpoint dashboard agrégé (`GET /api/v1/producer/dashboard`) pour le mobile ou pour des refresh client, il sera introduit par le ticket qui câblera la première section dynamique — pas par KAN-18.
+
+## Impact state machine / events
+
+Aucun. Pas de transition mission, pas d'event Inngest émis, pas de webhook Stripe consommé. Read-only.
+
+## Dépendances
+
+Services externes :
+
+- Aucun. Le dashboard ne dépend que de Supabase Postgres (Supabase Auth pour la session, Supabase DB pour la lecture). Statut : `tech/setup.md` § Supabase (ligne 14) — Partiel, dev OK.
+
+Internes :
+
+- `packages/db/users` (KAN-2) — `findById`
+- `packages/db/producers` (KAN-16 + KAN-17) — `findByUserId`
+- Layout existant `apps/web/app/(auth)/onboarding/producteur` reste indépendant ; le layout `/producer/*` ne s'applique qu'aux pages post-onboarding (vérifier le route group à l'implémentation)
+- Tokens et composants partagés `DESIGN.md` (couleurs greens / cream / earth, breakpoints `desktop:` 880 px)
+- Icônes : `lucide-react` (déjà dépendance du repo, à confirmer à l'implémentation) plutôt que SVG copiés depuis la maquette
+
+## État UI
+
+Référence : `DESIGN.md` (tokens, breakpoints), maquette `design/maquettes/producteur/pr-03-dashboard.html`.
+
+- **Layout `producer/layout.tsx`** : `<div class="app">` avec `<aside class="sb">` (240 px, sticky, masquée < 880 px) + `<main>` (max-width 1100 px, padding 26/32). Top sticky bar (`mobile-bar`) avec burger + logo visible < 880 px uniquement. Toutes les pages `/producer/*` sont mises dans ce shell.
+- **`<AppSidebar role items user activePath />`** : composant générique réutilisable. Reçoit la liste des liens depuis la page parent (au MVP, hardcodée pour le rôle producteur dans le layout via un helper `apps/web/lib/navigation/producer-nav.ts`). Items : `{ href, label, icon, badge?, disabled? }`. État actif basé sur `usePathname()`. Section headers visuels (« Activité » / « Catalogue » / « Finances » / « Profil ») conformes maquette. Items `disabled` : pas de `href`, `aria-disabled="true"`, opacité réduite, tooltip neutre « Disponible bientôt », focusable au clavier mais non-actionable.
+- **`<MobileTopbar />`** : visible < 880 px, ouvre un drawer modal contenant la sidebar.
+- **`<SiretBanner status reason? />`** : 4 variantes (`pending`, `verified` → null, `rejected`, `not_submitted`), styles distincts (orange / rouge / vert), CTA contextuel.
+- **`<StripeOnboardingBanner status />`** : visible si `stripe_status != 'active'`.
+- **`<PausedBanner />`** : visible si `producers.paused = true`.
+- **`<KpiCard label icon value? meta? state? />`** : 2 modes — `value` (réel) ou `state="coming"` (placeholder « — » + meta « Disponible bientôt »). Au MVP toutes les cards sont en `state="coming"`.
+- **`<SectionCard title actionHref? actionLabel? children>`** : container blanc avec header + lien droit + slot enfants.
+- **`<EmptyState icon text />`** : utilisé dans chaque section sans données. Microcopy neutre orienté utilisateur, jamais de référence à un ticket interne.
+- **Greeting header** : `<h1>Bonjour {first_name ?? ''}</h1>` + sous-titre statique. CTA « Nouveau produit » : `<button aria-disabled>` avec style atténué et tooltip « Disponible bientôt ».
+- **Responsive** : desktop ≥ 880 px (sidebar visible, grid KPI 4 colonnes, two-col 1.6/1), mobile < 880 px (sidebar drawer, grid KPI 2 colonnes, two-col mono-colonne). Conformément à la règle « responsive obligatoire » CLAUDE.md.
+- **Refactor pages existantes** : `/producer/profile` et `/producer/settings` perdent leur `<main>` autonome (déjà visible dans `profile-client.tsx:14-40`) et leur padding global au profit du layout parent. Le `<header>` interne (titre de la page) est conservé en haut du contenu de chaque page.
+
+## Risques techniques
+
+- **Tentation de mocker la donnée** : la maquette montre des chiffres réalistes (« 348 € », « 7 commandes », « Mission #M-3829 »). Risque que l'implémentation injecte des fixtures pour « rendre joli » la démo. Règle : aucune fixture en prod, **uniquement empty states** tant qu'aucune table n'alimente la section. Les fixtures vivent dans Storybook / tests, pas dans le bundle.
+- **Sidebar fragile à la dette** : 4 liens sur 7 pointent vers des routes inexistantes (Récupérations, Mes produits, Ajouter un produit, Ventes & virements). Le composant doit gérer proprement `disabled` (pas de `href`, `aria-disabled`, opacité 50 %) sans casser la navigation accessible. Tester au clavier (Tab focusable mais non-actionable).
+- **Couplage layout ↔ rôle** : si on hardcode « producteur » dans `producer/layout.tsx`, on devra dupliquer pour AC et RM. La voie choisie via `<AppSidebar role items />` évite ce piège — le layout fournit les items, le composant ne sait pas qu'il rend un espace producteur.
+- **Redirect rôle → espace correspondant** : le helper `getRoleHomePath(roles)` doit gérer le multi-rôles (un compte qui inclut `producteur` reste sur `/producer`) et la précédence des rôles. Tester explicitement les 7 combinaisons (`[p]`, `[a]`, `[r]`, `[p,a]`, `[p,r]`, `[a,r]`, `[p,a,r]`).
+- **Double lecture DB** : layout serveur + page enfant qui re-fetchent `producers` indépendamment. Au MVP, accepter la duplication (lecture cheap, RLS owner) ; si elle devient gênante, introduire `getProducerDashboardContext(userId)` qui regroupe les deux lectures et exposer via React `cache()` (Next 15 App Router).
+- **Bundle web** : la sidebar embarque ~10 icônes. Préférer `lucide-react` (déjà dépendance) plutôt que des SVG copiés depuis la maquette. Vérifier qu'on reste sous la cible bundle pour `/producer/*` (ARCHITECTURE.md §11/§13).
+- **Cas onboarding non terminé** : un producteur qui revient sur `/producer` alors qu'il n'a pas validé Stripe Connect doit pouvoir voir le dashboard mais avec le bon CTA contextualisé. Le banner SIRET ne suffit pas — il faut aussi `<StripeOnboardingBanner />` quand `stripe_status != 'active'`.
+- **Cas `paused = true`** : la maquette ne traite pas le cas « boutique en pause ». Ajouter `<PausedBanner />` en haut du dashboard cohérent avec `/producer/settings`.
+
+## Tests envisagés
+
+Référence : ARCHITECTURE.md §10.
+
+- **Unit `packages/core`** : aucun (pas de logique métier nouvelle).
+- **Unit `apps/web`** (Vitest + React Testing Library) :
+  - `<AppSidebar />` : affiche les bons items pour `role="producteur"`, l'item actif est highlight, les items `disabled` ne sont pas cliquables et exposent `aria-disabled="true"`.
+  - `<SiretBanner />` : rend la bonne variante pour chacun des 4 statuts.
+  - `<StripeOnboardingBanner />` : rendu conditionnel correct.
+  - `<PausedBanner />` : rendu conditionnel correct.
+  - `<KpiCard />` : empty state rend `« — »` sans valeur ; valeur réelle rendue quand fournie.
+  - `<EmptyState />` : rendu nominal.
+  - Helper `getRoleHomePath` : couvre les 7 combinaisons de rôles + cas vide (`/welcome`).
+- **Intégration DB** : non nécessaire (pas de nouvelle migration, pas de RLS nouvelle).
+- **E2E web Playwright** (`apps/web/e2e/producer-dashboard.spec.ts`) :
+  - Producteur connecté navigue `/producer` → voit le banner SIRET conforme à son statut + les sections empty state.
+  - Sidebar : clic sur « Profil public » → navigue vers `/producer/profile` ; les liens disabled ne naviguent pas.
+  - Responsive : viewport mobile (< 880 px), sidebar masquée, burger ouvre le drawer.
+  - Acheteur connecté tente d'accéder à `/producer` → redirect vers `/acheteur` (qui produira un 404 au MVP, acceptable — le test asserte juste la cible du redirect).
+  - Non-connecté tente d'accéder à `/producer` → redirect vers `/welcome`.
+- **Accessibilité** : axe-core check sur `/producer` (cible : 0 violation critique).

--- a/specs/KAN-18/proposal.md
+++ b/specs/KAN-18/proposal.md
@@ -1,0 +1,66 @@
+# Cadrage — KAN-18 Tableau de bord producteur
+
+## Liens
+
+- Jira : https://erkulaws.atlassian.net/browse/KAN-18
+- Epic : KAN-4 Profil Producteur
+- Maquette : `design/maquettes/producteur/pr-03-dashboard.html`
+- PRD : §10.2 PR-03 Dashboard
+- ARCHITECTURE : §3 (monorepo + layouts), §5 (DB — pas d'extension propre, lecture des tables futures), §9.2 (RLS — owner-only), §14 (playbook)
+
+## Pourquoi (côté tech)
+
+La maquette PR-03 est riche (KPIs, pickups, ventes escrow, virement Stripe, stock, activité), mais **presque toutes les sources de données qu'elle consomme n'existent pas encore** dans le schéma : `products` (KAN-20), `missions` / `mission_events` / `mission_buyers` (KAN-10), payouts Stripe (KAN-16 a posé le compte Connect mais pas la trace des transferts), avis (KAN-53). Seules les données posées par KAN-16/17 sont disponibles aujourd'hui : `producers` (SIRET status, `paused`, profil), `users`.
+
+Le vrai mouvement de KAN-18 est donc de livrer **l'enveloppe** :
+
+- la **sidebar producteur globale** prévue dès PR-03 mais réutilisée par PR-04 à PR-09 (cf. note dans `apps/web/app/producer/profile/profile-client.tsx:10` qui attendait justement KAN-18) ;
+- le **layout Next** `apps/web/app/producer/layout.tsx` qui factorise sidebar + topbar + responsive (burger < 880 px) pour toutes les pages producteur existantes et futures, et qui gère le **gating par rôle** (un acheteur ou un rameneur qui arrive sur `/producer/*` est redirigé vers son propre espace) ;
+- la **page `/producer`** (route racine du dashboard) qui compose les sections de la maquette avec des **empty states explicites** par bloc tant que la donnée n'est pas dispo, sans inventer un schéma factice ;
+- le **banner SIRET** (haut de PR-03) déjà spécifié visuellement, qui se branche sur `producers.siret_status` (déjà en DB depuis KAN-16) — première section réellement câblée.
+
+C'est aussi la première fois qu'on pose un **layout d'espace authentifié multi-pages** côté web (le wizard onboarding ne compte pas — single-page). Les conventions posées ici (sidebar component générique, structure de slots, breakpoints, gating « rôle producteur uniquement », redirect rôle → espace correspondant) seront reprises pour l'espace acheteur (AC-*) et l'espace rameneur (RM-*) dès leurs tickets respectifs.
+
+## Périmètre technique
+
+**In scope :**
+
+- Layout `apps/web/app/producer/layout.tsx` (server component) qui :
+  - vérifie l'authentification (sinon redirect `/welcome`) ;
+  - vérifie le rôle `producteur` sur la row `users` ; si l'utilisateur a un autre rôle, redirect vers son **espace correspondant** (`/acheteur` pour un acheteur, `/rameneur` pour un rameneur) via un helper `getRoleHomePath(roles)`. Comportement : un compte multi-rôles qui inclut `producteur` reste autorisé sur `/producer/*`. Un compte sans rôle producteur est renvoyé vers son premier rôle disponible. Au MVP, les routes `/acheteur` et `/rameneur` n'existent pas encore — le redirect aboutira à un 404 Next, acceptable et symboliquement correct (le pattern est posé, il se câblera dès l'arrivée de leurs tickets respectifs) ;
+  - charge la row `producers` du caller (SIRET status, `paused`, `display_name`) une seule fois et la fournit aux pages enfants via React context client ;
+  - redirige vers `/onboarding/producteur` si la row `producers` est absente ;
+  - rend la sidebar + topbar mobile + slot `{children}`.
+- Composant générique `<AppSidebar role="producteur" items={…} user={…} />` (client) : reçoit la liste des liens depuis le layout parent, paramétrable pour les futurs espaces. Items : Tableau de bord, Récupérations, Mes produits, Ajouter un produit, Ventes & virements, Profil public, Paramètres ; état actif basé sur `usePathname()` ; les liens vers des routes inexistantes sont visuellement présents mais `aria-disabled` + tooltip neutre (« Disponible bientôt »).
+- Composant `<MobileTopbar />` : burger + logo, breakpoint < 880 px (cf. maquette ligne 132-139), ouvre la sidebar en drawer.
+- Page `/producer` (`apps/web/app/producer/page.tsx`) — dashboard composé de :
+  - **Header** : « Bonjour {first_name} », sous-titre statique au MVP (« Bienvenue sur votre espace producteur »), CTA « Nouveau produit » `aria-disabled` avec tooltip « Disponible bientôt ».
+  - **SIRET banner** câblé sur `siret_status` (`pending` → bandeau orange « SIRET en cours de vérification », `verified` → masqué, `rejected` → bandeau rouge avec lien support, `not_submitted` → CTA « Compléter mon onboarding »).
+  - **Stripe onboarding banner** (conditionnel) : si `stripe_status != 'active'`, encart « Finalisez votre compte Stripe pour publier vos produits » avec CTA vers `/onboarding/producteur`.
+  - **Paused banner** (conditionnel) : si `producers.paused = true`, encart « Boutique en pause — vos produits ne sont pas visibles. Réactiver dans Paramètres ».
+  - **KPI grid** (4 cards) : tous en empty state au MVP (icône grisée + libellé « Disponible bientôt »), squelette prêt à recevoir les valeurs.
+  - **Sections** : « Prochaines récupérations », « Ventes en cours », « Stock à surveiller », « Prochain virement Stripe », « Activité récente » → chacune en empty state neutre, sans référence à des tickets internes.
+- Refactor minimal des pages existantes `/producer/profile` et `/producer/settings` pour adopter le nouveau layout (suppression de leur `<main>` autonome dans les *-client.tsx, branchement sur le contexte producteur partagé).
+- Responsive desktop + mobile obligatoire (cf. règle CLAUDE.md, breakpoints `DESIGN.md`).
+
+**Out of scope (cette US) :**
+
+- **Données réelles dans les KPIs / sections** : tant que les tables `missions`, `mission_events`, `products`, payouts Stripe n'existent pas, on ne câble rien. Chaque empty state est remplacé par sa source de données au fil des tickets (KAN-20 stock, KAN-10/11 missions, KAN-16+ payouts, KAN-53 avis).
+- **Alertes stock producteur** : KAN-56 (feature distincte, dépend de KAN-20).
+- **Notifications in-app dans la sidebar** (badge « 3 » sur Récupérations dans la maquette) : différé à KAN-55 qui exposera le compteur. Au MVP de KAN-18, pas de badge.
+- **Routes `/acheteur/*` et `/rameneur/*`** : non livrées ici (leurs propres tickets). KAN-18 pose seulement le helper `getRoleHomePath` qui les référence.
+- **Apps mobile** : non scaffoldé, différé global.
+- **Page racine `/producer` versus `/producer/dashboard`** : on choisit `/producer` comme racine (cohérent avec `/producer/profile`, `/producer/settings`). Pas de redirect `/dashboard` → `/producer`.
+- **Greeting dynamique avancé** (heure du jour, météo, etc.) : un simple « Bonjour {first_name} » suffit au MVP.
+- **Personnalisation / réorganisation des sections** par l'utilisateur : non, ordre figé conforme à la maquette.
+
+## Hypothèses
+
+- Le `first_name` affiché provient de `users.first_name` (déjà en DB depuis KAN-2). Si null, fallback sur « Bonjour ».
+- Le rôle `producteur` est lu via `users.roles` (table posée par KAN-2). Le check côté layout est une simple lecture de la session + lookup repo `users.findById(auth.uid())`.
+- Pas de nouveau endpoint API : le layout serveur lit en direct via les repos `users` et `producers` déjà existants (`getProducerByUserId`).
+- Pas de nouvelle migration DB. La feature est 100 % code applicatif (layout + composants + page).
+- La sidebar producteur sert de **référence pour l'espace acheteur et rameneur** : on livre dès KAN-18 un composant `<AppSidebar />` générique paramétré par `{ role, items, user }` plutôt qu'un composant `<ProducerSidebar />` figé — presque le même effort, évite la refonte plus tard.
+- Le contexte producteur partagé (`<ProducerContext>`) est volontairement minimaliste : `{ producer: ProducerSnapshot, user: UserSnapshot }`. Toute lecture additionnelle se fera via fetch dédié dans la page concernée, pas via extension du context.
+- Les CTA / liens « Disponible bientôt » restent **visuellement présents** plutôt que masqués : un producteur en onboarding voit son futur espace, c'est cohérent avec la promesse PR-03.
+- Aucun texte UI ne fait référence à un ticket interne (« KAN-XX »). Microcopy strictement orienté utilisateur final.

--- a/specs/KAN-18/tasks.md
+++ b/specs/KAN-18/tasks.md
@@ -1,0 +1,60 @@
+# Tâches techniques internes — KAN-18 Tableau de bord producteur
+
+> Ces tâches ne sont pas dans Jira. Setup, migrations, refacto, helpers partagés, seeds, configuration — tout ce qui n'a pas vocation à être tracké comme livrable produit.
+>
+> Subtasks Jira existantes (rappel — ne pas dupliquer ici) :
+> - (aucune au moment du cadrage — KAN-18 n'a pas de subtasks Jira créées)
+
+## Tâches
+
+- [ ] Helper `apps/web/lib/navigation/get-role-home-path.ts` :
+  - input `roles: UserRole[]`
+  - output `/producer | /acheteur | /rameneur | /welcome`
+  - tests Vitest sur les 7 combinaisons de rôles + cas vide
+- [ ] Helper `apps/web/lib/navigation/producer-nav.ts` :
+  - liste canonique des items sidebar producteur
+  - source unique pour le layout et les tests (`{ href, label, icon, disabled? }`)
+- [ ] Layout `apps/web/app/producer/layout.tsx` (server component) :
+  - vérification session (redirect `/welcome` sinon)
+  - vérification rôle `producteur` (redirect via `getRoleHomePath` sinon)
+  - lecture `users.findById` + `producers.findByUserId` (avec React `cache()` pour limiter les doubles lectures)
+  - redirect `/onboarding/producteur` si row `producers` absente
+  - rendu `<AppSidebar />` + `<MobileTopbar />` + `{children}`
+  - exposition du contexte `<ProducerContext.Provider>` (client) pour les pages enfants
+- [ ] Composant générique `apps/web/components/app/app-sidebar.tsx` :
+  - props `{ role, items, user, activePath }`
+  - sections headers, items, badges, disabled state
+  - icônes `lucide-react` (à confirmer en dépendance ; sinon ajouter)
+- [ ] Composant `apps/web/components/app/mobile-topbar.tsx` + drawer
+- [ ] Composant `apps/web/components/producer/siret-banner.tsx` (4 variantes)
+- [ ] Composant `apps/web/components/producer/stripe-onboarding-banner.tsx` (encart si `stripe_status != 'active'`)
+- [ ] Composant `apps/web/components/producer/paused-banner.tsx` (encart si `producers.paused = true`)
+- [ ] Composants dashboard `apps/web/components/dashboard/` :
+  - `kpi-card.tsx` (modes `value` / `coming`)
+  - `section-card.tsx`
+  - `empty-state.tsx`
+- [ ] Page `apps/web/app/producer/page.tsx` :
+  - greeting header + CTA « Nouveau produit » disabled (tooltip neutre)
+  - banners (SIRET + Stripe + paused) conditionnels
+  - grid 4 KPIs (tous empty)
+  - sections two-col (pickups + sales / stock + payout + activity) toutes empty
+- [ ] Refactor `apps/web/app/producer/profile/profile-client.tsx` : suppression du `<main>` autonome, branchement sur le layout parent + retrait du commentaire obsolète ligne 10
+- [ ] Refactor `apps/web/app/producer/settings/settings-client.tsx` : même refacto
+- [ ] Vérification : `/onboarding/producteur` est bien sous `(auth)` et n'hérite **pas** du layout `/producer/*` (sinon ajuster la structure des route groups)
+- [ ] Tests Vitest `apps/web/components/**/*.test.tsx` pour les composants nouveaux (5-6 specs)
+- [ ] Test E2E Playwright `apps/web/e2e/producer-dashboard.spec.ts` (5 scénarios : producteur dashboard, sidebar nav, responsive mobile, acheteur redirect, non-connecté redirect)
+- [ ] Vérification accessibilité (axe-core) sur `/producer`
+- [ ] Mise à jour `produit/jira_mapping.md` (cellule PR-03) : `[Cadrage tech](specs/KAN-18/)` ajouté à la colonne « Ticket(s) Jira principal(aux) »
+- [ ] Le commentaire ticket Jira en tête de `design/maquettes/producteur/pr-03-dashboard.html` cite déjà KAN-18 + KAN-56 — pas de modification nécessaire à l'implémentation
+
+## Checklist pre-merge
+
+Voir ARCHITECTURE.md §14.3 — ne pas dupliquer ici.
+
+## Décisions techniques structurantes introduites
+
+À ajouter au journal §18 d'`ARCHITECTURE.md` au moment de l'implémentation si confirmées :
+
+- **Pattern layout authentifié multi-pages** : `apps/web/app/producer/layout.tsx` est le premier exemple côté repo. Convention : un layout par espace de rôle (`/producer/*`, `/acheteur/*`, `/rameneur/*`), avec un composant `<AppSidebar />` générique paramétré.
+- **Helper `getRoleHomePath(roles)`** : source unique pour le routing par rôle (gating layout + post-login + post-onboarding). À étendre aux espaces acheteur et rameneur dès leurs tickets.
+- **Convention « empty states explicites plutôt que fixtures »** pour les écrans qui dépendent de tables non encore livrées. Microcopy strictement orienté utilisateur, jamais de référence à un ticket interne.


### PR DESCRIPTION
## Summary

Add comprehensive technical specification documents for KAN-18 (Tableau de bord producteur / Producer Dashboard), establishing the foundational layout pattern and UI structure for the producer workspace.

## Changes

- **`specs/KAN-18/design.md`** — Technical design document covering:
  - Architecture overview: server-side layout with role-based gating, sidebar + topbar pattern, responsive design
  - Data model: read-only access to existing `users` and `producers` tables; empty states for future data sources (products, missions, payouts, reviews)
  - UI components: generic `<AppSidebar />`, banners (SIRET/Stripe/paused), KPI cards, section cards, empty states
  - Responsive breakpoints (880px desktop/mobile threshold)
  - Technical risks and mitigation strategies (fixture injection, sidebar fragility, role coupling, double DB reads)
  - Test plan: unit tests for components, E2E scenarios, accessibility checks

- **`specs/KAN-18/proposal.md`** — Scope and rationale document covering:
  - Why: deliver the application envelope (layout, sidebar, gating) while data sources are still being built
  - In-scope: layout server component, generic sidebar, mobile topbar, dashboard page with empty states, refactor existing profile/settings pages
  - Out-of-scope: real data in KPIs (deferred to KAN-20, KAN-10, KAN-53), mobile apps, advanced greeting logic
  - Key assumptions: `first_name` from `users`, role check via `users.roles`, no new API endpoints, no DB migrations

- **`specs/KAN-18/tasks.md`** — Internal task checklist covering:
  - Helper functions: `getRoleHomePath()` (7 role combinations), `producer-nav.ts` (sidebar items)
  - Components: `<AppSidebar />`, `<MobileTopbar />`, banners (SIRET/Stripe/paused), dashboard cards
  - Page implementation: greeting, banners, KPI grid, sections (all empty state at MVP)
  - Refactoring: profile and settings pages to adopt new layout
  - Testing: Vitest unit tests, Playwright E2E scenarios, accessibility verification
  - Pre-merge checklist reference

- **`produit/jira_mapping.md`** — Updated PR-03 Dashboard row to link to KAN-18 technical specification

## Implementation Notes

- **Pattern established**: First authenticated multi-page layout for a role-based workspace. Conventions (generic sidebar component, role-based routing helper, empty state approach) will be reused for buyer (`/acheteur/*`) and driver (`/rameneur/*`) spaces.
- **No new endpoints or migrations**: Pure application code (layout + components + page).
- **Empty states by design**: Sections remain explicitly empty until their data sources are delivered by dependent tickets (KAN-20 products, KAN-10 missions, etc.), avoiding fixture injection into production code.
- **Accessibility-first**: Disabled sidebar items remain focusable with `aria-disabled`, proper ARIA labels, keyboard navigation support.
- **Responsive-first**: Mobile drawer sidebar, 2-column KPI grid on mobile vs. 4-column on desktop, all per DESIGN.md breakpoints.

This specification is ready for implementation and serves as the reference for the producer dashboard UI structure and the authenticated layout pattern for future role-based workspaces.

https://claude.ai/code/session_01SRwWxkedj8vJqqRpQPqTd2