### PR TITLE
Mapping Jira : KAN-18 en Terminé (merge PR #21)

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -9,7 +9,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 - **13 épics** (KAN-1, KAN-4 → KAN-15) — un épic par grand domaine fonctionnel
 - **50 features cataloguées** (KAN-2, KAN-3 sous KAN-1 ; KAN-16 → KAN-158 sous les autres épics — voir tables par épic ci-dessous)
 - **Subtasks** : voir le catalogue par épic ci-dessous. Le mapping peut être incomplet pour les subtasks les plus récentes — Jira fait foi pour la liste exhaustive.
-- État au 2026-05-17 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-17 *Terminé* (mergé sur `main` — PR #18, cadrage `specs/KAN-17/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; autres *Ideas*
+- État au 2026-05-18 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-17 *Terminé* (mergé sur `main` — PR #18, cadrage `specs/KAN-17/`) ; KAN-18 *Terminé* (mergé sur `main` — PR #21, cadrage `specs/KAN-18/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; autres *Ideas*
 - **Maquettes (2026-05-14)** : les 35 écrans des 3 parcours (Producteur, Acheteur, Rameneur) du sitemap PRD §10 sont maquettés. Restent à maquetter : transverses **TR-02** (centre notifications) et **TR-04** (signalement / litige) ; **TR-03** est couvert par `rm-09-chat.html`. Index navigable de toutes les maquettes : `design/maquettes/index.html`
 
 ## Convention de référencement
@@ -103,7 +103,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | KAN-4 | Epic | Ideas | Profil Producteur |
 | KAN-16 | Feature | Terminé | Onboarding Stripe Connect — [Cadrage tech](specs/KAN-16/) — mergé sur main (PR #10) |
 | KAN-17 | Feature | Terminé | Informations profil & ferme — [Cadrage tech](specs/KAN-17/) — mergé sur main (PR #18) |
-| KAN-18 | Feature | À faire | Tableau de bord producteur — [Cadrage tech](specs/KAN-18/) |
+| KAN-18 | Feature | Terminé | Tableau de bord producteur — [Cadrage tech](specs/KAN-18/) — mergé sur main (PR #21) |
 | KAN-19 | Feature | Ideas | Historique ventes |
 | KAN-158 | Feature | Terminé | Polish UX onboarding producteur — état Stripe restricted (KYC incomplet) — [Cadrage tech](specs/KAN-158/) — mergé sur main (PR #15) |
 | KAN-62 | Subtask | Ideas | Connecter son compte bancaire via Stripe Connect (KYC léger + IBAN) — parent KAN-16 |


### PR DESCRIPTION
## Résumé

Cleanup post-merge KAN-18 (cf. règle CLAUDE.md « Après merge d'une feature sur `main` »).

- Catalogue épic KAN-4 : KAN-18 `À faire` → `Terminé` avec mention `mergé sur main (PR #21)`
- Section « Vue d'ensemble » : `État au 2026-05-17` → `État au 2026-05-18`, KAN-18 ajouté à la liste des Terminés
- Ticket Jira KAN-18 transitionné vers `Terminé` (transition `51`)

## Statut épic parent

L'épic **KAN-4 Profil Producteur** comporte encore **KAN-19** (*Historique ventes*) en statut `Ideas` — pas de clôture d'épic à signaler.

## Test plan

- [x] Mapping mis à jour avec PR #21 et date 2026-05-18
- [x] Jira KAN-18 passé en Terminé


---
_Generated by [Claude Code](https://claude.ai/code/session_01SRwWxkedj8vJqqRpQPqTd2)_