### PR TITLE
Workflow PR : auto-merge + transitions Jira pilotées par events de merge

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -25,8 +25,21 @@ specs/KAN-XX/.
    stack, dérogation à une règle ARCHITECTURE.md), ajouter une entrée au
    journal §18 d'ARCHITECTURE.md dans le même commit que le code
    concerné.
-6. À la fin : ouvrir une PR via gh, description listant les subtasks Jira
-   couvertes et les tâches tasks.md cochées.
+6. **Au premier push sur `claude/kan-XX-<slug>`** :
+   - Transitionner le ticket Jira `À faire` → `Wip` (transition id `31`).
+   - Ouvrir la PR « implémentation KAN-XX » via `create_pull_request`
+     (description : subtasks Jira couvertes + tâches `tasks.md` cochées).
+   - Activer l'auto-merge squash via
+     `enable_pr_auto_merge(merge_method: "SQUASH")`. Si l'option repo est
+     désactivée, le signaler sans bloquer.
+   - Souscrire à l'activité PR via `subscribe_pr_activity`.
+7. Continuer à pousser des commits sur la branche au fil de
+   l'implémentation — la PR se met à jour automatiquement et l'auto-merge
+   attend la CI verte.
+8. Au reçu de l'event de merge : appliquer le cas B de CLAUDE.md
+   § « Après merge d'une PR KAN-XXX sur `main` » — transition
+   `Wip → Examiner` (id `41`, **jamais Terminé**), commit mapping,
+   `unsubscribe_pr_activity`.
 
 ## Conventions
 - Format de commit : `[KAN-XX] verbe + objet`. Pas de préfixe

--- a/.claude/commands/propose.md
+++ b/.claude/commands/propose.md
@@ -11,4 +11,4 @@ Suivre la procédure du skill dans son intégralité :
 2. Vérifier l'idempotence (le dossier `specs/$ARGUMENTS/` existe-t-il déjà ?)
 3. Générer les trois specs en mémoire à partir des templates
 4. Présenter le brouillon en chat et attendre une validation explicite
-5. Après validation : écrire les fichiers, mettre à jour Jira (commentaire + section description + transition vers To Do), mettre à jour `produit/jira_mapping.md`, et commit `[$ARGUMENTS] ouverture cadrage`
+5. Après validation : écrire les fichiers, mettre à jour Jira (commentaire + section description, sans transition — `Ideas → À faire` est déclenchée au merge), mettre à jour `produit/jira_mapping.md`, commit `[$ARGUMENTS] ouverture cadrage`, push, ouvrir la PR avec auto-merge squash et souscrire à l'activité PR pour traiter le post-merge

--- a/.claude/skills/propose-spec/SKILL.md
+++ b/.claude/skills/propose-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: propose-spec
-description: Cadrage technique d'une feature Jira KAN du projet Delta. Génère trois specs courtes (proposal.md, design.md, tasks.md) à partir d'un ticket, met à jour Jira (commentaire + lien + transition To Do) et synchronise produit/jira_mapping.md. Déclenche dès que l'utilisateur tape /propose KAN-XXX, demande à "cadrer", "framer", "spécifier" ou "préparer techniquement" un ticket KAN, veut traduire une feature produit en brief technique, ou cherche à passer du produit à la tech avant d'attaquer le dev. Active aussi sur "écris les specs tech de KAN-XX", "génère le cadrage de KAN-XX", "prépare KAN-XX pour le dev". Toute demande de cadrage technique sur un ticket KAN doit déclencher ce skill, même si le mot "spec" n'est pas prononcé.
+description: Cadrage technique d'une feature Jira KAN du projet Delta. Génère trois specs courtes (proposal.md, design.md, tasks.md) à partir d'un ticket, met à jour Jira (commentaire + lien), synchronise produit/jira_mapping.md, ouvre la PR cadrage avec auto-merge squash et déclenche la transition Ideas → À faire au merge. Déclenche dès que l'utilisateur tape /propose KAN-XXX, demande à "cadrer", "framer", "spécifier" ou "préparer techniquement" un ticket KAN, veut traduire une feature produit en brief technique, ou cherche à passer du produit à la tech avant d'attaquer le dev. Active aussi sur "écris les specs tech de KAN-XX", "génère le cadrage de KAN-XX", "prépare KAN-XX pour le dev". Toute demande de cadrage technique sur un ticket KAN doit déclencher ce skill, même si le mot "spec" n'est pas prononcé.
 ---
 
 # propose-spec — Cadrage technique d'une feature Jira KAN
@@ -59,24 +59,26 @@ Pré-remplir les sections évidentes (liens, références) ; laisser les section
 
 Afficher les trois fichiers en blocs Markdown distincts. Demander une validation explicite (`ok`, `valide`, ou `corrige X puis valide`). N'écrire aucun fichier tant que la validation n'est pas obtenue. Si l'utilisateur demande des corrections, les appliquer en mémoire et redemander.
 
-### 5. Après validation : écrire et synchroniser
+### 5. Après validation : écrire, pousser, ouvrir la PR avec auto-merge
 
-Dans cet ordre exact :
+Dans cet ordre :
 
 1. Créer `specs/KAN-XXX/` à la racine du repo Delta
 2. Écrire les trois fichiers
 3. Mettre à jour Jira :
    - **Commentaire** : `Cadrage technique disponible : specs/KAN-XXX/proposal.md, design.md, tasks.md`
    - **Description** : ajouter en bas une section `## Cadrage technique` listant les trois chemins (Markdown). Ne **jamais** copier le contenu des specs dans Jira — uniquement les liens. Source de vérité = repo.
-4. Transitionner le ticket vers `To Do` :
-   - `getTransitionsForJiraIssue` pour récupérer les transitions disponibles
-   - Si une transition vers le statut `To Do` (ou son équivalent dans le workflow KAN) existe, l'appliquer
-   - Si le ticket est déjà à un statut plus avancé (`In Progress`, `Done`, etc.), ne rien faire et le signaler en chat
-5. Mettre à jour `produit/jira_mapping.md` :
+   - **Ne pas transitionner le ticket à ce stade** — il reste en `Ideas` jusqu'au merge de la PR cadrage. La transition `Ideas → À faire` (id `21`) est déclenchée par l'event de merge (cf. CLAUDE.md § « Après merge d'une PR KAN-XXX sur `main` »).
+4. Mettre à jour `produit/jira_mapping.md` :
    - Localiser le ticket dans les tables de parcours (Producteur / Acheteur / Rameneur / Transverse)
    - Ajouter ou mettre à jour une mention `[Cadrage tech](specs/KAN-XXX/)` dans la cellule du ticket
    - Si le ticket est transverse (apparaît dans plusieurs tables), mettre à jour partout
-6. Commit Git unique : `[KAN-XXX] ouverture cadrage`
+5. Commit Git unique : `[KAN-XXX] ouverture cadrage`
+6. Push de la branche `claude/propose-kan-XXX-<slug>` vers `origin`
+7. Ouvrir la PR « specs KAN-XXX » via `create_pull_request`
+8. **Activer l'auto-merge squash** via `enable_pr_auto_merge(merge_method: "SQUASH")`. Si l'option repo est désactivée ou si la branche est protégée d'une manière incompatible, le signaler en chat sans bloquer.
+9. **Souscrire à l'activité PR** via `subscribe_pr_activity` pour traiter le post-merge dans la même session.
+10. Au reçu de l'event de merge : appliquer le cas A de la règle « Après merge d'une PR KAN-XXX sur `main` » (transition `21`, commit mapping, `unsubscribe_pr_activity`).
 
 ## Règles strictes
 
@@ -102,7 +104,7 @@ Si le cadrage révèle une décision structurante (changement de stack, nouvelle
 - **Ticket sans description Jira** : utiliser `(à préciser — voir maquette + PRD)` comme `{{DESCRIPTION_BRIEF}}`. Le cadrage devient un brouillon à compléter.
 - **Pas de maquette** : `(non disponible)`. Le signaler en fin de chat si l'écran devrait en avoir une.
 - **Ticket transverse** : mettre à jour toutes les tables concernées du mapping.
-- **Statut non transitionable vers To Do** : ne pas tenter, signaler le statut courant. Le reste du workflow (fichiers, mapping, commit) reste fait.
+- **Ticket déjà au-delà de `Ideas` (`À faire`, `Wip`, etc.)** : ne pas tenter de revenir en arrière. Signaler le statut courant en chat. Le reste du workflow (fichiers, mapping, commit, PR, auto-merge, souscription) reste fait.
 
 ## Templates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,33 +209,49 @@ Pour préparer techniquement une feature Jira KAN avant de coder, utiliser le sk
 - Définition complète et workflow : `.claude/skills/propose-spec/SKILL.md`.
 
 ### Cadrage → implémentation : deux branches, deux PRs — règle impérative
-`/propose KAN-XX` et `/implement KAN-XX` produisent du contenu **différent en nature** (cadrage docs vs code applicatif). Pour pouvoir reviewer / merger l'un sans bloquer l'autre, ils vivent sur deux branches distinctes et ouvrent deux PRs séparées :
+`/propose KAN-XX` et `/implement KAN-XX` produisent du contenu **différent en nature** (cadrage docs vs code applicatif). Pour pouvoir reviewer / merger l'un sans bloquer l'autre, ils vivent sur deux branches distinctes et ouvrent deux PRs séparées, chacune avec son cycle de transitions Jira :
 
-| Étape | Slug branche | Contenu typique | PR |
+| Étape | Slug branche | Action agent | Transition Jira |
 |---|---|---|---|
-| `/propose KAN-XX` | `claude/propose-kan-XX-<slug>` | `specs/KAN-XX/{proposal,design,tasks}.md`, MAJ mapping, transition Jira `To Do` | « specs KAN-XX » |
-| `/implement KAN-XX` | `claude/kan-XX-<slug>` | Migrations, contracts, core, API, UI, tests, transition Jira `Wip` | « implémentation KAN-XX » |
+| Fin de `/propose KAN-XX` | `claude/propose-kan-XX-<slug>` | Push, ouvre PR « specs KAN-XX », **active GitHub auto-merge squash**, souscrit à l'activité PR | aucune (reste `Ideas`) |
+| Merge PR cadrage (CI verte → auto-merge) | — | Event merge → transition + commit mapping, désabonne | `Ideas` → `À faire` (id `21`) |
+| 1er push sur `claude/kan-XX-<slug>` (début `/implement KAN-XX`) | `claude/kan-XX-<slug>` | Push, ouvre PR « implémentation KAN-XX », **active GitHub auto-merge squash**, souscrit | `À faire` → `Wip` (id `31`) |
+| Merge PR implémentation (CI verte → auto-merge) | — | Event merge → transition + commit mapping, désabonne | `Wip` → `Examiner` (id `41`) |
+| Validation produit / QA | — | Humain (jamais automatique) | `Examiner` → `Terminé` (id `51`) |
 
 **Conséquences pratiques :**
+- L'agent active `enable_pr_auto_merge(squash)` à la création de chaque PR (cadrage et implémentation). Prérequis repo : « Allow auto-merge » activé dans `Settings → General → Pull Requests`. Si l'auto-merge ne peut pas être activé (option repo désactivée, branche protégée incompatible), l'agent le signale en chat et laisse la PR en merge manuel.
+- L'agent souscrit à l'activité PR (`subscribe_pr_activity`) au moment où il pousse la PR, pour traiter le post-merge dans la même session : transition Jira + commit mapping + désabonnement. Si la session se termine avant le merge, le post-merge est ramassé par la session suivante via la règle « Après merge d'une PR KAN-XXX sur `main` ».
+- La transition `Wip` est **déclenchée au premier push** sur `claude/kan-XX-<slug>`, pas au démarrage du skill `/implement`. Tant que rien n'est poussé, le ticket reste en `À faire`.
 - Quand l'environnement remote démarre une session `/implement KAN-XX`, le harness doit l'ouvrir sur `claude/kan-XX-<slug>`, **pas** sur la branche `claude/propose-kan-XX-*` du cadrage. Si la session démarre par erreur sur la branche propose alors que le cadrage est déjà mergé, **créer une nouvelle branche locale `claude/kan-XX-<slug>` depuis main et y placer tous les commits d'implémentation** avant le `git push`.
-- Le ticket Jira passe en `To Do` à la fin de `/propose`, puis en `Wip` à la fin de `/implement` (transitions `21` puis `31` dans le workflow KAN, cf. `getTransitionsForJiraIssue`).
-- Le ticket Jira passe en `Terminé` quand la PR d'implémentation est mergée (cf. section « Après merge d'une feature sur `main` »). La PR de cadrage est `merge` aussi, mais elle ne déclenche pas la transition `Terminé` — son merge n'est qu'une étape intermédiaire.
+- La transition vers `Terminé` (id `51`) est **toujours manuelle** : produit ou QA valide en aval. L'agent ne déclenche jamais cette transition.
 
-**Origine de la règle :** observée sur KAN-17 (2026-05-17) — `/propose` et `/implement` ont tourné sur la même branche `claude/propose-kan-17-lWOkr`, le cadrage a été mergé via PR #17 dès qu'il a été poussé, puis les 6 commits d'implémentation suivants ont été pushés sur la même branche sans nouvelle PR. Résultat : implémentation invisible sur `main` jusqu'à ouverture manuelle d'une seconde PR depuis une nouvelle branche.
+**Origine de la règle :** observée sur KAN-17 (2026-05-17) — `/propose` et `/implement` ont tourné sur la même branche `claude/propose-kan-17-lWOkr`. Workflow révisé le 2026-05-18 après merge de KAN-19 : passage à l'auto-merge sur CI verte + transitions Jira pilotées par les événements de merge.
 
-### Après merge d'une feature sur `main` — règle impérative
-Quand une PR portant une feature KAN-XXX est mergée sur `main` (origin), le ticket Jira correspondant doit être basculé en **Terminé** et le mapping mis à jour, **sans attendre**. Sinon la vue Jira reste désynchronisée du repo et la prochaine session ne sait plus ce qui est livré.
+### Après merge d'une PR KAN-XXX sur `main` — règle impérative
+La cible visée est l'auto-merge GitHub : à la création de chaque PR (cadrage ou implémentation), l'agent active `enable_pr_auto_merge(squash)` et souscrit à l'activité PR. Quand la CI passe, GitHub merge automatiquement et l'agent reçoit l'event dans la même session. Cas de figure :
 
-À faire dans la foulée du merge (manuellement ou via un agent dédié) :
+**Cas A — PR cadrage `claude/propose-kan-XX-*` mergée :**
+1. Transitionner le ticket Jira `Ideas` → `À faire` (transition id `21`, cf. `getTransitionsForJiraIssue`).
+2. Mettre à jour `produit/jira_mapping.md` :
+   - Ligne du ticket dans la table « Catalogue Jira complet » de l'épic concerné : statut passe à `À faire`, mention `[Cadrage tech](specs/KAN-XX/)` déjà présente.
+   - Ligne « État au YYYY-MM-DD » de la « Vue d'ensemble » : sortir le ticket du bloc « *Ideas* » et le mentionner en `À faire (cadrage)`.
+3. Commit dédié : `Mapping Jira : KAN-XX en À faire (merge cadrage PR #N)`.
+4. `unsubscribe_pr_activity` sur la PR cadrage.
 
-1. **Transitionner le ticket Jira** vers `Terminé` (transition id `51` dans le workflow KAN, cf. `getTransitionsForJiraIssue`). Si le ticket est en `Wip` ou `Examiner`, la transition directe vers `Terminé` est disponible — pas besoin de passer par les états intermédiaires.
-2. **Mettre à jour `produit/jira_mapping.md`** :
-   - Statut du ticket dans la table « Catalogue Jira complet » de l'épic concerné : `Wip` / `Examiner` → `Terminé`, avec mention du PR de merge entre tirets (ex : `— mergé sur main (PR #N)`)
-   - Ligne « État au YYYY-MM-DD » de la section « Vue d'ensemble » mise à jour avec le nouveau statut
-3. **Commit dédié** : `Mapping Jira : KAN-XXX en Terminé (merge PR #N)`. Ne pas mélanger avec d'autres modifications.
-4. **Si l'épic parent voit toutes ses features passées en `Terminé`**, le signaler en chat — la clôture d'épic est une décision manuelle (parfois on garde l'épic ouvert pour des sous-tickets de polish).
+**Cas B — PR implémentation `claude/kan-XX-*` mergée :**
+1. Transitionner le ticket Jira `Wip` → `Examiner` (transition id `41`). **Ne jamais transitionner vers `Terminé` automatiquement** — c'est une validation produit / QA manuelle.
+2. Mettre à jour `produit/jira_mapping.md` :
+   - Ligne du ticket dans la table « Catalogue Jira complet » : statut passe à `Examiner`, mention `— mergé sur main (PR #N)` entre tirets.
+   - Ligne « État au YYYY-MM-DD » : mise à jour avec le nouveau statut.
+3. Commit dédié : `Mapping Jira : KAN-XX en Examiner (merge PR #N)`.
+4. `unsubscribe_pr_activity` sur la PR implémentation.
 
-Cette règle complète la règle « Après toute création, modification ou suppression de ticket Jira » qui couvre déjà les changements de structure, et la règle `/propose` qui couvre la transition d'entrée vers `To Do`. C'est la fermeture symétrique du cycle.
+**Si la session a été perdue avant l'event de merge** (timeout, redémarrage harness), la session suivante détecte le décalage en relisant `produit/jira_mapping.md` vs l'état Jira et applique le cas A ou B correspondant.
+
+**Transition `Terminé` (id `51`) :** déclenchée manuellement par le produit / QA après recette du ticket. L'agent ne transitionne **jamais** vers `Terminé`. Quand toutes les features d'un épic sont en `Terminé`, le signaler en chat — clôture de l'épic = décision manuelle.
+
+Cette règle complète la règle « Après toute création, modification ou suppression de ticket Jira » qui couvre les changements de structure, et la matrice de la règle « Cadrage → implémentation : deux branches, deux PRs » qui définit le cycle complet.
 
 ### Hiérarchie en cas de conflit entre sources
 **Sur sujets produit / fonctionnels :**


### PR DESCRIPTION
## Résumé

Refonte du workflow de PR pour passer à l'auto-merge GitHub sur CI verte et aux transitions Jira pilotées par les événements de merge plutôt que par la fin du skill.

## Nouvelle matrice

| Étape | Action agent | Transition Jira |
|---|---|---|
| Fin de `/propose KAN-XX` | Push, ouvre PR cadrage, **active auto-merge squash**, souscrit | aucune (reste `Ideas`) |
| Merge PR cadrage | Event merge → transition + commit mapping, désabonne | `Ideas` → `À faire` (id `21`) |
| 1er push sur `claude/kan-XX-*` | Push, ouvre PR implémentation, **active auto-merge squash**, souscrit | `À faire` → `Wip` (id `31`) |
| Merge PR implémentation | Event merge → transition + commit mapping, désabonne | `Wip` → `Examiner` (id `41`) |
| Validation produit / QA | Humain | `Examiner` → `Terminé` (id `51`) |

## Fichiers touchés

- `CLAUDE.md` — sections « Cadrage → implémentation : deux branches, deux PRs » et « Après merge d'une PR KAN-XXX sur main » réécrites
- `.claude/skills/propose-spec/SKILL.md` — frontmatter + étape 5 (retire la transition `À faire`, ajoute push + auto-merge + souscription + post-merge cas A) + cas limite
- `.claude/commands/propose.md` — résumé du step 5 aligné
- `.claude/commands/implement.md` — section « Workflow d'implémentation » : transition `Wip` au premier push, ouverture PR + auto-merge + souscription, post-merge cas B (`Examiner`, jamais `Terminé`)

## Différences clés vs ancien workflow

- **Avant** : `/propose` transitionnait Jira à `À faire` en fin de skill, avant le merge. `/implement` transitionnait à `Wip` en fin de skill. Le merge de la PR implémentation transitionnait à `Terminé`.
- **Après** : Les transitions sont pilotées par les events de merge GitHub. `Terminé` devient **strictement manuel** (validation produit / QA en aval). `Wip` est déclenché au **premier push** sur la branche implémentation, pas au démarrage du skill.

## Prérequis repo

« Allow auto-merge » doit être activé dans `Settings → General → Pull Requests`. Si désactivé, l'agent le signale en chat sans bloquer.

## Test plan

- [ ] Auto-merge squash s'active correctement sur cette PR (première application du nouveau workflow)
- [ ] CI verte → merge automatique sans intervention manuelle

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdvZTpSG47qRE2z6Gt5eo6)_