### PR TITLE
Mapping Jira : KAN-19 en Examiner (merge PR #25)

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -9,7 +9,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 - **13 épics** (KAN-1, KAN-4 → KAN-15) — un épic par grand domaine fonctionnel
 - **50 features cataloguées** (KAN-2, KAN-3 sous KAN-1 ; KAN-16 → KAN-158 sous les autres épics — voir tables par épic ci-dessous)
 - **Subtasks** : voir le catalogue par épic ci-dessous. Le mapping peut être incomplet pour les subtasks les plus récentes — Jira fait foi pour la liste exhaustive.
-- État au 2026-05-18 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-17 *Terminé* (mergé sur `main` — PR #18, cadrage `specs/KAN-17/`) ; KAN-18 *Terminé* (mergé sur `main` — PR #21, cadrage `specs/KAN-18/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; KAN-19 *À faire* (cadrage `specs/KAN-19/`) ; autres *Ideas*
+- État au 2026-05-18 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-17 *Terminé* (mergé sur `main` — PR #18, cadrage `specs/KAN-17/`) ; KAN-18 *Terminé* (mergé sur `main` — PR #21, cadrage `specs/KAN-18/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; KAN-19 *Examiner* (mergé sur `main` — PR #25, cadrage `specs/KAN-19/`) ; autres *Ideas*
 - **Maquettes (2026-05-14)** : les 35 écrans des 3 parcours (Producteur, Acheteur, Rameneur) du sitemap PRD §10 sont maquettés. Restent à maquetter : transverses **TR-02** (centre notifications) et **TR-04** (signalement / litige) ; **TR-03** est couvert par `rm-09-chat.html`. Index navigable de toutes les maquettes : `design/maquettes/index.html`
 
 ## Convention de référencement
@@ -104,7 +104,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | KAN-16 | Feature | Terminé | Onboarding Stripe Connect — [Cadrage tech](specs/KAN-16/) — mergé sur main (PR #10) |
 | KAN-17 | Feature | Terminé | Informations profil & ferme — [Cadrage tech](specs/KAN-17/) — mergé sur main (PR #18) |
 | KAN-18 | Feature | Terminé | Tableau de bord producteur — [Cadrage tech](specs/KAN-18/) — mergé sur main (PR #21) |
-| KAN-19 | Feature | À faire | Historique ventes — [Cadrage tech](specs/KAN-19/) |
+| KAN-19 | Feature | Examiner | Historique ventes — [Cadrage tech](specs/KAN-19/) — mergé sur main (PR #25) |
 | KAN-158 | Feature | Terminé | Polish UX onboarding producteur — état Stripe restricted (KYC incomplet) — [Cadrage tech](specs/KAN-158/) — mergé sur main (PR #15) |
 | KAN-62 | Subtask | Ideas | Connecter son compte bancaire via Stripe Connect (KYC léger + IBAN) — parent KAN-16 |
 | KAN-63 | Subtask | Ideas | Renseigner ses informations de profil (nom, description, photo) — parent KAN-17 |


### PR DESCRIPTION
## Résumé

Synchronisation du mapping après merge de la PR d'implémentation KAN-19 (#25). Cas B de la règle CLAUDE.md « Après merge d'une PR KAN-XXX sur `main` » :

- Ligne KAN-19 du catalogue KAN-4 : statut passe de `À faire` à `Examiner`, mention `— mergé sur main (PR #25)` ajoutée
- Ligne « État au 2026-05-18 » de la « Vue d'ensemble » : KAN-19 sort du bloc cadrage et est ajouté aux features en `Examiner`

Le ticket Jira a été transitionné `Wip → Examiner` (id `41`) en parallèle. Pas de transition automatique vers `Terminé` — c'est manuel après validation produit / QA.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdvZTpSG47qRE2z6Gt5eo6)_