### PR TITLE
Workflow PR : chaînage automatique cadrage → implémentation au merge

### DIFF
--- a/.claude/commands/propose.md
+++ b/.claude/commands/propose.md
@@ -11,4 +11,4 @@ Suivre la procédure du skill dans son intégralité :
 2. Vérifier l'idempotence (le dossier `specs/$ARGUMENTS/` existe-t-il déjà ?)
 3. Générer les trois specs en mémoire à partir des templates
 4. Présenter le brouillon en chat et attendre une validation explicite
-5. Après validation : écrire les fichiers, mettre à jour Jira (commentaire + section description, sans transition — `Ideas → À faire` est déclenchée au merge), mettre à jour `produit/jira_mapping.md`, commit `[$ARGUMENTS] ouverture cadrage`, push, ouvrir la PR avec auto-merge squash et souscrire à l'activité PR pour traiter le post-merge
+5. Après validation : écrire les fichiers, mettre à jour Jira (commentaire + section description, sans transition — `Ideas → À faire` est déclenchée au merge), mettre à jour `produit/jira_mapping.md`, commit `[$ARGUMENTS] ouverture cadrage`, push, ouvrir la PR avec auto-merge squash, souscrire à l'activité PR ; au merge, traiter le post-merge (cas A) et enchaîner automatiquement sur `/implement $ARGUMENTS`

--- a/.claude/skills/propose-spec/SKILL.md
+++ b/.claude/skills/propose-spec/SKILL.md
@@ -78,7 +78,7 @@ Dans cet ordre :
 7. Ouvrir la PR « specs KAN-XXX » via `create_pull_request`
 8. **Activer l'auto-merge squash** via `enable_pr_auto_merge(merge_method: "SQUASH")`. Si l'option repo est désactivée ou si la branche est protégée d'une manière incompatible, le signaler en chat sans bloquer.
 9. **Souscrire à l'activité PR** via `subscribe_pr_activity` pour traiter le post-merge dans la même session.
-10. Au reçu de l'event de merge : appliquer le cas A de la règle « Après merge d'une PR KAN-XXX sur `main` » (transition `21`, commit mapping, `unsubscribe_pr_activity`).
+10. Au reçu de l'event de merge : appliquer le cas A complet de la règle « Après merge d'une PR KAN-XXX sur `main` » — transition `21`, PR mapping avec auto-merge, `unsubscribe_pr_activity`, puis **enchaînement automatique sur le skill `implement` avec l'argument `KAN-XXX`** (checkout main + nouvelle branche `claude/kan-XXX-<slug>` + Skill tool). Pas de confirmation chat.
 
 ## Règles strictes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ Pour préparer techniquement une feature Jira KAN avant de coder, utiliser le sk
 | Étape | Slug branche | Action agent | Transition Jira |
 |---|---|---|---|
 | Fin de `/propose KAN-XX` | `claude/propose-kan-XX-<slug>` | Push, ouvre PR « specs KAN-XX », **active GitHub auto-merge squash**, souscrit à l'activité PR | aucune (reste `Ideas`) |
-| Merge PR cadrage (CI verte → auto-merge) | — | Event merge → transition + commit mapping, désabonne | `Ideas` → `À faire` (id `21`) |
+| Merge PR cadrage (CI verte → auto-merge) | — | Event merge → cas A : transition + PR mapping + désabonne + **enchaîne `/implement KAN-XX` automatiquement** | `Ideas` → `À faire` (id `21`) |
 | 1er push sur `claude/kan-XX-<slug>` (début `/implement KAN-XX`) | `claude/kan-XX-<slug>` | Push, ouvre PR « implémentation KAN-XX », **active GitHub auto-merge squash**, souscrit | `À faire` → `Wip` (id `31`) |
 | Merge PR implémentation (CI verte → auto-merge) | — | Event merge → transition + commit mapping, désabonne | `Wip` → `Examiner` (id `41`) |
 | Validation produit / QA | — | Humain (jamais automatique) | `Examiner` → `Terminé` (id `51`) |
@@ -222,6 +222,7 @@ Pour préparer techniquement une feature Jira KAN avant de coder, utiliser le sk
 **Conséquences pratiques :**
 - L'agent active `enable_pr_auto_merge(squash)` à la création de chaque PR (cadrage et implémentation). Prérequis repo : « Allow auto-merge » activé dans `Settings → General → Pull Requests`. Si l'auto-merge ne peut pas être activé (option repo désactivée, branche protégée incompatible), l'agent le signale en chat et laisse la PR en merge manuel.
 - L'agent souscrit à l'activité PR (`subscribe_pr_activity`) au moment où il pousse la PR, pour traiter le post-merge dans la même session : transition Jira + commit mapping + désabonnement. Si la session se termine avant le merge, le post-merge est ramassé par la session suivante via la règle « Après merge d'une PR KAN-XXX sur `main` ».
+- **Chaînage automatique cadrage → implémentation** : à la réception de l'event de merge de la PR cadrage (que la session soit l'agent initial ou un agent de rattrapage), le cas A inclut l'invocation directe du skill `implement` avec `KAN-XX`. Pas de confirmation chat. L'utilisateur peut interrompre à tout moment.
 - La transition `Wip` est **déclenchée au premier push** sur `claude/kan-XX-<slug>`, pas au démarrage du skill `/implement`. Tant que rien n'est poussé, le ticket reste en `À faire`.
 - Quand l'environnement remote démarre une session `/implement KAN-XX`, le harness doit l'ouvrir sur `claude/kan-XX-<slug>`, **pas** sur la branche `claude/propose-kan-XX-*` du cadrage. Si la session démarre par erreur sur la branche propose alors que le cadrage est déjà mergé, **créer une nouvelle branche locale `claude/kan-XX-<slug>` depuis main et y placer tous les commits d'implémentation** avant le `git push`.
 - La transition vers `Terminé` (id `51`) est **toujours manuelle** : produit ou QA valide en aval. L'agent ne déclenche jamais cette transition.
@@ -236,15 +237,22 @@ La cible visée est l'auto-merge GitHub : à la création de chaque PR (cadrage 
 2. Mettre à jour `produit/jira_mapping.md` :
    - Ligne du ticket dans la table « Catalogue Jira complet » de l'épic concerné : statut passe à `À faire`, mention `[Cadrage tech](specs/KAN-XX/)` déjà présente.
    - Ligne « État au YYYY-MM-DD » de la « Vue d'ensemble » : sortir le ticket du bloc « *Ideas* » et le mentionner en `À faire (cadrage)`.
-3. Commit dédié : `Mapping Jira : KAN-XX en À faire (merge cadrage PR #N)`.
+3. Commit dédié sur branche `claude/mapping-kan-XX-a-faire`, push, ouvrir PR mapping avec auto-merge squash. Titre/message : `Mapping Jira : KAN-XX en À faire (merge cadrage PR #N)`. (Main étant protégé, la PR mapping est obligatoire.)
 4. `unsubscribe_pr_activity` sur la PR cadrage.
+5. **Enchaîner automatiquement sur `/implement KAN-XX`** dans la même session, sans demander de confirmation :
+   - `git checkout main && git pull origin main`
+   - Créer la branche `claude/kan-XX-<slug>` depuis `main`
+   - Invoquer le skill `implement` avec l'argument `KAN-XX` (via Skill tool)
+   - L'utilisateur peut interrompre à tout moment dans le chat (« stop », « on s'arrête au cadrage »)
+
+Ce chaînage s'applique **aussi aux sessions de rattrapage** qui détectent un cadrage mergé non-suivi d'implémentation : la session de rattrapage exécute le cas A complet, y compris l'étape 5. La cohérence prime sur la surprise — relire `produit/jira_mapping.md` + état Jira renseigne toujours sur l'étape en cours.
 
 **Cas B — PR implémentation `claude/kan-XX-*` mergée :**
 1. Transitionner le ticket Jira `Wip` → `Examiner` (transition id `41`). **Ne jamais transitionner vers `Terminé` automatiquement** — c'est une validation produit / QA manuelle.
 2. Mettre à jour `produit/jira_mapping.md` :
    - Ligne du ticket dans la table « Catalogue Jira complet » : statut passe à `Examiner`, mention `— mergé sur main (PR #N)` entre tirets.
    - Ligne « État au YYYY-MM-DD » : mise à jour avec le nouveau statut.
-3. Commit dédié : `Mapping Jira : KAN-XX en Examiner (merge PR #N)`.
+3. Commit dédié sur branche `claude/mapping-kan-XX-examiner`, push, ouvrir PR mapping avec auto-merge squash. Titre/message : `Mapping Jira : KAN-XX en Examiner (merge PR #N)`.
 4. `unsubscribe_pr_activity` sur la PR implémentation.
 
 **Si la session a été perdue avant l'event de merge** (timeout, redémarrage harness), la session suivante détecte le décalage en relisant `produit/jira_mapping.md` vs l'état Jira et applique le cas A ou B correspondant.


### PR DESCRIPTION
## Résumé

Ajoute le chaînage automatique `/propose` → `/implement` au merge de la PR cadrage. Quand la CI valide la PR cadrage et que GitHub auto-merge sur `main`, le cas A post-merge (transition Jira `Ideas → À faire`, PR mapping, désabonnement) est suivi **dans la même session** par l'invocation automatique du skill `implement` sur le ticket.

## Détails

- **Pas de confirmation chat** — chaînage direct, l'utilisateur peut interrompre à tout moment dans la conversation.
- **S'applique aussi aux sessions de rattrapage** — si la session `/propose` a expiré avant le merge, la session suivante qui détecte le décalage exécute le cas A complet, étape 5 incluse.
- **PR mapping formalisée** : les commits mapping (cas A et cas B) doivent désormais passer par une branche dédiée (`claude/mapping-kan-XX-a-faire` ou `claude/mapping-kan-XX-examiner`) puisque `main` est protégé. C'est ce qu'on faisait déjà en pratique (cf. PR #22, #26), maintenant explicite dans la règle.

## Fichiers touchés

- `CLAUDE.md` :
  - Matrice « Cadrage → implémentation : deux branches, deux PRs » — ligne « Merge PR cadrage » mentionne l'enchaînement
  - Bloc « Conséquences pratiques » — nouvelle puce sur le chaînage
  - Cas A de « Après merge d'une PR KAN-XXX sur main » — nouvelle étape 5 + précision PR mapping
  - Cas B — précision PR mapping
- `.claude/skills/propose-spec/SKILL.md` — étape 10 du workflow inclut le chaînage
- `.claude/commands/propose.md` — résumé du step 5 aligné

## Test plan

- [ ] CI Vercel verte → auto-merge
- [ ] Première application réelle au prochain `/propose KAN-XX`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdvZTpSG47qRE2z6Gt5eo6)_