### PR TITLE
[KAN-20] Cadrage technique — Création & édition produit

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -9,7 +9,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 - **13 épics** (KAN-1, KAN-4 → KAN-15) — un épic par grand domaine fonctionnel
 - **50 features cataloguées** (KAN-2, KAN-3 sous KAN-1 ; KAN-16 → KAN-158 sous les autres épics — voir tables par épic ci-dessous)
 - **Subtasks** : voir le catalogue par épic ci-dessous. Le mapping peut être incomplet pour les subtasks les plus récentes — Jira fait foi pour la liste exhaustive.
-- État au 2026-05-18 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-17 *Terminé* (mergé sur `main` — PR #18, cadrage `specs/KAN-17/`) ; KAN-18 *Terminé* (mergé sur `main` — PR #21, cadrage `specs/KAN-18/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; KAN-19 *Examiner* (mergé sur `main` — PR #25, cadrage `specs/KAN-19/`) ; autres *Ideas*
+- État au 2026-05-18 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-17 *Terminé* (mergé sur `main` — PR #18, cadrage `specs/KAN-17/`) ; KAN-18 *Terminé* (mergé sur `main` — PR #21, cadrage `specs/KAN-18/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; KAN-19 *Examiner* (mergé sur `main` — PR #25, cadrage `specs/KAN-19/`) ; KAN-20 *Ideas* (cadrage en cours, branche `claude/propose-kan-20-GrBpe`) ; autres *Ideas*
 - **Maquettes (2026-05-14)** : les 35 écrans des 3 parcours (Producteur, Acheteur, Rameneur) du sitemap PRD §10 sont maquettés. Restent à maquetter : transverses **TR-02** (centre notifications) et **TR-04** (signalement / litige) ; **TR-03** est couvert par `rm-09-chat.html`. Index navigable de toutes les maquettes : `design/maquettes/index.html`
 
 ## Convention de référencement
@@ -30,8 +30,8 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | PR-01 Inscription / connexion | `pr-01-authentication.html` | KAN-2 (Création de compte), KAN-3 (Connexion), KAN-157 (Récup. mot de passe) | [Cadrage KAN-2](specs/KAN-2/), [Cadrage KAN-3](specs/KAN-3/), [Cadrage KAN-157](specs/KAN-157/) |
 | PR-02 Onboarding Stripe Connect | `pr-02-onboarding-stripe.html` | KAN-16 (Onboarding Stripe Connect) — [Cadrage tech](specs/KAN-16/) | KAN-62, KAN-158 (polish UX restricted) |
 | PR-03 Dashboard | `pr-03-dashboard.html` | KAN-18 (Tableau de bord producteur) — [Cadrage tech](specs/KAN-18/) | KAN-56 |
-| PR-04 Catalogue produits | `pr-04-catalogue.html` | KAN-20 (Création & édition produit) | KAN-23 (Statuts produit) |
-| PR-05 Création / édition produit | `pr-05-edition-produit.html` | KAN-20 (Création & édition produit) | KAN-21 (Photos), KAN-22 (Stock), KAN-24 (Labels & catégories) |
+| PR-04 Catalogue produits | `pr-04-catalogue.html` | KAN-20 (Création & édition produit) — [Cadrage tech](specs/KAN-20/) | KAN-23 (Statuts produit) |
+| PR-05 Création / édition produit | `pr-05-edition-produit.html` | KAN-20 (Création & édition produit) — [Cadrage tech](specs/KAN-20/) | KAN-21 (Photos), KAN-22 (Stock), KAN-24 (Labels & catégories) |
 | PR-06 Récupération à venir | `pr-06-recuperation.html` | KAN-46 (QR Pickup), KAN-47 (Checklist remise producteur) | KAN-45 |
 | PR-07 Historique ventes | `pr-07-historique-ventes.html` | KAN-19 (Historique ventes) — [Cadrage tech](specs/KAN-19/) | KAN-36 (Factures PDF) |
 | PR-08 Profil public producteur | `pr-08-profil-public.html` | KAN-17 (Informations profil & ferme) — [Cadrage tech](specs/KAN-17/) | KAN-53 (Profils publics & avis), KAN-63, KAN-64, KAN-65, KAN-66 |
@@ -117,7 +117,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | Ticket | Type | Statut | Résumé |
 |--------|------|--------|--------|
 | KAN-5 | Epic | Ideas | Catalogue |
-| KAN-20 | Feature | Ideas | Création & édition produit |
+| KAN-20 | Feature | Ideas | Création & édition produit — [Cadrage tech](specs/KAN-20/) (branche `claude/propose-kan-20-GrBpe`) |
 | KAN-21 | Feature | Ideas | Gestion photos |
 | KAN-22 | Feature | Ideas | Stock & alertes |
 | KAN-23 | Feature | Ideas | Statuts produit |

--- a/specs/KAN-20/design.md
+++ b/specs/KAN-20/design.md
@@ -1,0 +1,157 @@
+# Conception technique — KAN-20 Création & édition produit
+
+## Vue d'ensemble
+
+Une seule migration crée la table `products` avec toutes les colonnes que les tickets frères de l'épic KAN-5 vont câbler (photos, labels, seuil d'alerte), de manière à ne pas re-migrer la table 4 fois. KAN-20 livre la logique CRUD complète (endpoints, validation, use cases, repo) et l'UI minimale (liste + formulaire) qui couvre les champs de la subtask KAN-69. Les sections de la maquette qui dépendent d'autres tickets sont rendues en placeholder sans logique applicative.
+
+Le mouvement principal est conservatif : on suit le pattern KAN-17 (formulaire unique + page d'édition + endpoint PATCH + Zod + use cases). Pas de state machine ni d'event Inngest — c'est un CRUD pur. La complexité du ticket réside dans la délimitation propre des frontières vis-à-vis de KAN-21/22/23/24 et dans la RLS multi-cas (owner R/W, public lecture conditionnelle).
+
+## Packages touchés
+
+- [x] `packages/contracts` — `productCreateSchema`, `productUpdateSchema`, `productListQuerySchema`, snapshot output
+- [x] `packages/core` — use cases `createProduct`, `updateProduct`, `softDeleteProduct`, `listOwnerProducts`, `getOwnerProduct` + erreurs typées
+- [x] `packages/db` — repo `products` (`create`, `findById`, `findByOwner`, `update`, `softDelete`), helpers FTS query
+- [x] `apps/web` — pages `/producer/catalogue`, `/producer/catalogue/nouveau`, `/producer/catalogue/[id]`, route handlers `app/api/v1/producer/products/{,[id]}/route.ts`
+- [ ] `apps/mobile` — hors scope
+- [ ] `packages/jobs` — aucun job
+- [x] `supabase/migrations` — création table `products`, enums, RLS, FTS, index, CHECK
+- [x] `supabase/policies` — `products.sql` (réécrit : remplacer le placeholder documentaire par les vraies policies, ou supprimer si la migration les intègre directement — voir Tâches)
+- [ ] `packages/ui-web` — composants placés directement dans `apps/web/components/producer/catalogue/` (pas de réutilisation cross-app prévue au MVP)
+
+## Modèle de données
+
+Table `public.products` (création neuve). Toutes les colonnes optionnelles à part le minimum requis pour qu'un produit existe.
+
+| Colonne | Type | Note |
+|---|---|---|
+| `id` | `uuid pk default gen_random_uuid()` | |
+| `producer_user_id` | `uuid not null references public.users(id) on delete cascade` | FK vers `producers.user_id` (1-1 avec `users`) |
+| `name` | `text not null` | CHECK 1 ≤ length ≤ 120 |
+| `description` | `text` | CHECK length ≤ 2000 |
+| `category` | `product_category not null` | ENUM (8 valeurs, cf. ci-dessous) |
+| `packaging` | `product_packaging not null` | ENUM (8 valeurs, cf. ci-dessous) |
+| `unit_price_cents` | `integer not null` | CHECK > 0 et ≤ 100_000 (1 000 €) ; prix net producteur |
+| `stock` | `integer not null default 0` | CHECK ≥ 0 |
+| `low_stock_threshold` | `integer` | CHECK ≥ 0 ; nullable ; câblé par KAN-22 |
+| `availability_from` | `date` | nullable (= disponible immédiatement) |
+| `availability_to` | `date` | nullable (= sans limite) ; CHECK `availability_to >= availability_from` quand les deux sont set |
+| `status` | `product_status not null default 'active'` | ENUM ; full workflow KAN-23 |
+| `labels` | `text[] not null default '{}'` | Stocké en `text[]` au MVP ; swap → `product_label[]` par KAN-24 |
+| `photos` | `jsonb not null default '[]'` | Array `{ url, alt? }` ; CHECK `jsonb_array_length ≤ 4` ; câblé par KAN-21 |
+| `search_vector` | `tsvector generated always as (...) stored` | FTS sur `name` + `description` (poids A + B), config `french` |
+| `created_at` | `timestamptz not null default now()` | |
+| `updated_at` | `timestamptz not null default now()` | trigger `public.set_updated_at()` (déjà installé par `20260510120000_init.sql`) |
+| `deleted_at` | `timestamptz` | soft delete |
+
+Nouveaux ENUM :
+
+- `product_category` : `'miel_et_ruche' | 'fruits' | 'legumes' | 'cereales_legumineuses' | 'conserves_confitures' | 'pain_biscuits' | 'huiles' | 'boissons_non_alcoolisees'` (alcool exclu — décision produit hors scope MVP).
+- `product_packaging` : `'pot_250g' | 'pot_500g' | 'pot_1kg' | 'bouteille_50cl' | 'bouteille_75cl' | 'sachet_500g' | 'carton_6' | 'au_kilo'`.
+- `product_status` : `'active' | 'draft' | 'disabled'`.
+
+Pour les labels : Postgres ne supporte pas un enum vide, et KAN-24 n'a pas encore défini ses valeurs. Décision retenue → stocker en `text[]` au MVP de KAN-20 (vide par défaut, validé Zod côté contracts), puis KAN-24 fera un swap colonne `text[]` → `product_label[]` dans sa propre migration. Documenter dans le journal ARCHITECTURE §18.
+
+Index :
+
+- `(producer_user_id, status) WHERE deleted_at IS NULL` — listing producteur (cf. ARCHITECTURE §5.4)
+- `GIN (search_vector)` — FTS
+- `(producer_user_id, deleted_at) WHERE deleted_at IS NOT NULL` — admin / RGPD post-MVP
+
+RLS sur `products` (toutes les policies dans la migration) :
+
+- `products_select_owner` (FOR SELECT TO authenticated USING `auth.uid() = producer_user_id`) — le producteur voit toujours ses produits, y compris soft-deleted (utile à un futur écran « corbeille ») et tous statuts.
+- `products_select_public` (FOR SELECT TO anon, authenticated USING `auth.uid() <> producer_user_id AND ...`) — reproduit le placeholder : producer vérifié + payouts ON + paused = false + deleted_at IS NULL + status = 'active' + (availability_from IS NULL OR availability_from ≤ current_date) + (availability_to IS NULL OR availability_to ≥ current_date).
+- `products_insert_owner` (FOR INSERT WITH CHECK `auth.uid() = producer_user_id`).
+- `products_update_owner` (FOR UPDATE TO authenticated USING `auth.uid() = producer_user_id` WITH CHECK `auth.uid() = producer_user_id`).
+- Pas de `products_delete_owner` : DELETE physique non utilisé, la suppression passe par `UPDATE deleted_at`.
+
+Référence : ARCHITECTURE.md §5, §9.2.
+
+## API / Endpoints
+
+Versionnés `/api/v1/`, validés Zod, handlers 15-30 lignes (cf. ARCHITECTURE §3, §14.2).
+
+- `GET /api/v1/producer/products` → liste des produits du producteur connecté. Query Zod : `status?: 'all'|'active'|'draft'|'disabled'`, `q?: string` (FTS), `limit?: number ≤ 50`, `cursor?: string`. Renvoie `{ items, nextCursor }`.
+- `POST /api/v1/producer/products` → création. Input `productCreateSchema` (name, category, packaging, unit_price_cents, stock, availability_from?, availability_to?, description?, status?). Renvoie le snapshot complet.
+- `GET /api/v1/producer/products/[id]` → lecture par owner (RLS filtre les autres).
+- `PATCH /api/v1/producer/products/[id]` → partial update. Input `productUpdateSchema` (tous optionnels sauf invariants). Recalcul `updated_at` côté DB (trigger existant).
+- `DELETE /api/v1/producer/products/[id]` → soft delete : `UPDATE products SET deleted_at = now() WHERE id = $1 AND producer_user_id = auth.uid() AND deleted_at IS NULL`.
+
+Erreurs typées (ARCHITECTURE §4.3) : `PRODUCT_NOT_FOUND`, `PRODUCT_FORBIDDEN`, `PRODUCT_INVALID_PRICE`, `PRODUCT_INVALID_AVAILABILITY_WINDOW`, `PRODUCT_NAME_TOO_LONG`, `PRODUCT_ALREADY_DELETED`.
+
+## Impact state machine / events
+
+Aucun. Pas de transition mission impactée, pas d'event Inngest émis dans ce ticket (cf. proposal — `product.updated` reste théorique tant que KAN-42 n'arrive pas).
+
+## Dépendances
+
+Services externes :
+- **Supabase Storage** — `tech/setup.md` § Supabase ligne 25 (bucket `product-photos` existe déjà, créé à l'init le 2026-05-08). Non consommé par KAN-20 (consommation par KAN-21).
+- Aucune autre dépendance externe.
+
+Internes :
+- Table `users` (KAN-2) et `producers` (KAN-16) — FK et conditions RLS.
+- Placeholder `supabase/policies/products.sql` (introduit par KAN-16) — **supprimé** par la migration KAN-20 (sa raison d'être disparaît).
+- Trigger `public.set_updated_at()` (migration init `20260510120000_init.sql`) — réutilisé.
+
+## État UI
+
+Référence : DESIGN.md (tokens, breakpoints) ; maquettes PR-04 et PR-05 lues intégralement.
+
+**Page `/producer/catalogue` (PR-04) :**
+- Layout : sidebar producteur (réutilisée de PR-03/PR-08/PR-09) + main page max-width 1200.
+- Stats banner : 4 cards (Produits actifs / Envies / Récup. à venir / Revenus). Seul « Produits actifs » est dérivé du listing KAN-20. Les 3 autres affichent `—` et un libellé « Bientôt » au MVP.
+- Tabs filtres `Tous / Actifs / Brouillons / Désactivés` câblés au query param `status`. Recherche FTS (input contrôlé, debounce 300 ms, envoi via `q`).
+- Products grid : `repeat(auto-fill, minmax(240px, 1fr))`. Carte = image placeholder gradient (cf. maquette) + nom + catégorie + prix + stock + fenêtre. Pas de compteurs Envies/Vendus (rendus `—` ou retirés au MVP).
+- Empty state : illustration + bouton CTA → `/producer/catalogue/nouveau`.
+- Responsive : mêmes breakpoints que les autres pages producteur (sidebar fixe < 920 px, grid mono-colonne < 540 px).
+
+**Page `/producer/catalogue/nouveau` et `/producer/catalogue/[id]` (PR-05) :**
+- Layout : split 2 colonnes desktop (édition + preview sticky, breakpoint < 1080 px → mono-colonne).
+- Sections du form (cf. maquette PR-05) :
+  - **Section 1 — Identité** : `name`, `category` (select), `description`. Câblé.
+  - **Section 2 — Photos** : grille `photo-uploader` rendue en **désactivée** (overlay « Bientôt — KAN-21 »). Pas de logique upload.
+  - **Section 3 — Prix et conditionnement** : `unit_price_cents` (input préfixe €), `packaging` (select). Le toggle « afficher prix voisin tout compris » est **retiré** au MVP.
+  - **Section 4 — Stock et disponibilité** : `stock` (input + unit derived from packaging), `low_stock_threshold` désactivé (« Bientôt — KAN-22 »), `availability_from` + `availability_to` (date pickers).
+  - **Section 5 — Visibilité** : tri-état (`active` / `draft` / `disabled`). Câblé en édition uniquement (les conséquences workflow restent KAN-23 : au MVP de KAN-20, changer le statut est purement persistant, sans validations d'éligibilité).
+- Sticky `actions-bar` : « Annuler » → retour catalogue, « Enregistrer » → POST/PATCH puis redirection vers liste.
+- Mode `nouveau` : pas de `id` dans l'URL, valeurs par défaut (`stock = 0`, `status = active`, `availability_*` vides). Bouton « Supprimer » (subtask KAN-71) ajouté en mode édition uniquement, dans un sous-menu de l'`actions-bar` (confirmation modale « Supprimer ce produit ? Action réversible 30 j. »).
+- Preview right column (PR-05 panel droit) : carte mockée vue acheteur, dérivée du state local. Note pédagogique « Ajoutez une photo… » conservée même si la section photos est désactivée.
+
+**Composants nouveaux dans `apps/web/components/producer/catalogue/` :**
+- `<CatalogueList />`, `<CatalogueFilters />`, `<ProductCard />`, `<ProductForm />`, `<ProductFormPreview />`, `<ProductDeleteConfirm />`.
+
+Mobile : non livré (cohérent avec KAN-17/18 — `apps/mobile/` non scaffold).
+
+## Risques techniques
+
+- **Soft delete + RLS** : `products_select_owner` doit inclure les soft-deleted (utile pour annulation post-MVP), mais l'API `GET /producer/products` doit filtrer `deleted_at IS NULL` par défaut côté repo. Si on oublie ce filtre, le producteur voit ses produits supprimés dans la liste. Test explicite à écrire.
+- **FTS configuration `french`** : la migration init n'a pas explicité de dictionnaire. Vérifier qu'`extensions` expose `french` config (par défaut sur Supabase, mais à valider). Sinon basculer sur `simple` en attendant (perte d'accents/stemming).
+- **Enum vs `text[]` pour labels** : décision retenue de stocker `labels text[]` au MVP pour éviter une migration enum-vide impossible. KAN-24 swap → enum dans sa propre migration. Documenter cette dette dans `tasks.md` + tag `// KAN-24 swap` côté repo.
+- **CHECK `availability_to >= availability_from`** : doit utiliser `CHECK (availability_from IS NULL OR availability_to IS NULL OR availability_to >= availability_from)` (sinon il refuse les `null`).
+- **Quantité d'index** : 3 index sur une table neuve, c'est OK (volume faible). À surveiller si la table dépasse 100k rows post-MVP.
+- **Suppression du placeholder `supabase/policies/products.sql`** : ne pas oublier dans le commit. Sinon doublon trompeur.
+- **`unit_price_cents` int** : 1 000 € max suffit largement (le plus cher dans les exemples est 15 €). Hard cap à 100 000 cents en DB.
+- **Statut `draft` éditable sans validation** : un producteur peut publier (`status = 'active'`) un produit sans description ni photos. Au MVP de KAN-20 on l'accepte (l'écran l'autorise via les radios). KAN-23 ajoutera les pré-requis de publication.
+
+## Tests envisagés
+
+Référence : ARCHITECTURE.md §10.
+
+- **Unit `packages/core`** :
+  - Validation `productCreateSchema` / `productUpdateSchema` (bornes nom, prix, stock, fenêtre, enums).
+  - Use case `createProduct` : succès, refus si producer non-existant (FK), refus si prix ≤ 0.
+  - Use case `softDeleteProduct` : succès puis idempotence (deleted_at déjà set → erreur typée).
+  - Use case `listOwnerProducts` : tri date desc, exclusion `deleted_at IS NOT NULL`, filtre `status`, recherche `q`.
+- **Intégration DB (Vitest + Supabase local quand disponible)** :
+  - RLS `products_select_owner` : le producteur voit ses produits actifs + brouillons + désactivés + soft-deleted.
+  - RLS `products_select_public` : un acheteur ne voit que des produits actifs d'un producteur vérifié + payouts ON + non en pause + dans la fenêtre de disponibilité.
+  - CHECK contraintes (longueur nom, prix borné, stock ≥ 0, fenêtre cohérente, max 4 photos).
+  - Trigger `set_updated_at` se déclenche bien sur PATCH.
+- **E2E web Playwright** (`apps/web/e2e/producer-catalogue.spec.ts`) :
+  - Producteur ouvre `/producer/catalogue` vide, clique « Nouveau produit », remplit le form minimal, enregistre, voit son produit dans la liste.
+  - Édition : modifier prix, recharger, prix persisté.
+  - Suppression : confirmer dans la modale, le produit disparaît de la liste.
+  - Filtres : créer 1 produit `active` + 1 `draft`, vérifier que les tabs filtrent correctement.
+  - Recherche FTS : créer 2 produits avec noms différents, recherche → 1 résultat.
+- **Tests Storage / photos** : différés (KAN-21).

--- a/specs/KAN-20/proposal.md
+++ b/specs/KAN-20/proposal.md
@@ -1,0 +1,54 @@
+# Cadrage — KAN-20 Création & édition produit
+
+## Liens
+
+- Jira : https://erkulaws.atlassian.net/browse/KAN-20
+- Epic : KAN-5 Catalogue
+- Maquettes :
+  - `design/maquettes/producteur/pr-04-catalogue.html` (liste catalogue + vide state)
+  - `design/maquettes/producteur/pr-05-edition-produit.html` (formulaire CRUD)
+- PRD : §10.2 PR-04 Catalogue produits, §10.2 PR-05 Création / édition produit
+- ARCHITECTURE : §3 (monorepo), §5 (DB — création table `products`), §7.1 (event `product.updated` consommé par matching, hors livraison KAN-20), §9 (RLS), §10 (tests), §14 (playbook)
+
+## Pourquoi (côté tech)
+
+KAN-17 et KAN-16 ont livré la couche `producers` (vérification SIRET, Stripe Connect, profil ferme, photos, adresse). Le producteur peut configurer son compte mais ne peut pas encore le rendre vendeur : il n'a pas de catalogue. KAN-20 ouvre la table `products` et livre le CRUD fondamental — création, lecture liste, édition, suppression douce. C'est la première fois qu'on instancie l'objet « produit » côté domaine, et c'est le préalable matérialisé à toutes les features de l'épic KAN-5 (photos, stock, statuts, labels) et à plusieurs features cousines (wishlist KAN-30, catalogue acheteur KAN-28, opportunités KAN-42).
+
+Le ticket s'aligne sur la subtask KAN-69 : « créer un produit avec nom, description, catégorie, prix net, stock et fenêtre de disponibilité ». Les champs photos / labels / alertes stock présents dans la maquette PR-05 sont **préparés en DB** (colonnes nullable) mais leur UI et leur logique sont délibérément laissées aux tickets dédiés.
+
+## Périmètre technique
+
+**In scope :**
+
+- Migration `products` : schéma complet de la table (avec colonnes nullable pour photos/labels/seuil afin que KAN-21/22/24 ne re-migrent pas), index `(producer_user_id, status) WHERE deleted_at IS NULL`, index GIN FTS sur `name + description` (cf. ARCHITECTURE §5.4), CHECK contraintes, RLS complète intégrant le placeholder `supabase/policies/products.sql` + suppression de ce placeholder.
+- Enums DB : `product_category` (8 valeurs alignées sur la maquette PR-05), `product_packaging` (8 valeurs idem), `product_status` (`active`, `draft`, `disabled`) — la valeur par défaut est `active` au MVP de KAN-20 (le workflow complet « brouillon → publication » est porté par KAN-23).
+- Endpoints `/api/v1/producer/products` : `GET` (liste owner), `POST` (create), `GET /[id]`, `PATCH /[id]`, `DELETE /[id]` (soft delete via `deleted_at`).
+- Validation Zod (`packages/contracts/src/product/`) + use cases core (`packages/core/src/product/`) + repo (`packages/db/src/products/`).
+- Page `/producer/catalogue` (PR-04) : liste, filtres par statut (tabs « Tous / Actifs / Brouillons / Désactivés », pré-câblés mais pas tous fonctionnels avant KAN-23), recherche FTS, vide state, bouton « Nouveau produit ». Stats banner uniquement avec « Produits actifs » (les 3 autres KPI = placeholders dépendants d'autres tickets).
+- Page `/producer/catalogue/nouveau` et `/producer/catalogue/[id]` (PR-05) : form CRUD avec sections 1 (identité), 3 (prix + conditionnement), 4 (stock + fenêtre), 5 (statut → tri-état seulement câblé sur `active` au MVP, brouillon/désactivé livrés UI mais sans logique de gating différenciée — finalisé par KAN-23).
+- Soft delete : `DELETE` set `deleted_at = now()` ; le repo expose toujours `WHERE deleted_at IS NULL` par défaut.
+- Gating RLS lecture publique : `products_select_public` reproduit le placeholder (verified + payouts_enabled + paused = false + deleted_at IS NULL) ; le producteur voit ses propres rows toujours.
+- Tests unitaires Zod + use cases + tests RLS minimaux (intégration owner/anon).
+
+**Out of scope (cette US) :**
+
+- **Photos** (KAN-21) : la colonne `photos jsonb` (max 4 entries, CHECK en DB) et le bucket `product-photos` (déjà provisionné dans `tech/setup.md`) sont préparés ; aucune UI d'upload ni route signature ici. Le visuel de la maquette PR-05 section 2 est livré en placeholder désactivé.
+- **Stock — seuil d'alerte + notifs** (KAN-22) : la colonne `low_stock_threshold int` est créée mais l'UI et les jobs notification (event `product.stock_low` côté Inngest, cf. KAN-56) sont hors scope. La cellule « stock bas » de la maquette PR-04 est rendue (style visuel uniquement, sans alerte applicative).
+- **Workflow statuts** (KAN-23) : le champ `status` accepte les trois valeurs en DB et est éditable depuis le form, mais les règles métier de transition (ex. « `draft` → `active` exige photos + description ») et le filtre « Brouillons » de la liste ne sont pas câblés — ils relèvent de KAN-23.
+- **Labels & catégories étendues** (KAN-24) : la colonne `labels text[]` est créée vide ; aucune UI de sélection chips. Catégorie obligatoire au MVP via le `select` natif de PR-05 (8 valeurs enum dur).
+- **Toggle « afficher prix voisin tout compris »** (PR-05 section 3) : pas livré au MVP. Le `unit_price_cents` reste le prix net producteur (85 % décision produit 2026-05-01) ; la conversion en prix tout-compris pour l'affichage acheteur sera dérivée à la lecture (catalogue acheteur, KAN-28).
+- Toute consommation du catalogue côté acheteur / matching : KAN-28 / KAN-42.
+- Mobile : non livré (`apps/mobile/` reste non-scaffold, cohérent avec KAN-16/17/18).
+- Event Inngest `product.updated` (ARCHITECTURE §7.1) : émis depuis les use cases ? **Non au MVP de KAN-20** — l'event sera câblé par KAN-42 (matching) qui s'abonnera à des hooks DB ou émettra depuis ses propres handlers. KAN-20 reste pur CRUD.
+
+## Hypothèses
+
+- La table `products` n'existe pas encore (placeholder `supabase/policies/products.sql` confirme). KAN-20 est donc « green-field » sur le catalogue.
+- Soft-delete via `deleted_at` aligné avec le pattern déjà documenté en ARCHITECTURE §5.4 (« partial `WHERE deleted_at IS NULL` »). Pas de table d'archivage séparée. La subtask KAN-71 = soft delete (UI + endpoint) ; un hard delete RGPD éventuel sera traité globalement (backlog post-MVP).
+- `unit_price_cents` est exclusivement le prix net producteur. La calculatrice « 85 % / 10 % / 5 % » de répartition reste l'apanage du module paiement (KAN-33/34). La maquette helper « Prix net que vous touchez : 85% du montant » est un message d'UI mais n'introduit aucune logique calculatoire ici.
+- `stock` est un entier simple (unités du conditionnement). Le seuil d'alerte est nullable. Pas d'historique de variations stock à ce stade — toute consommation (réservation par mission) sera modélisée par KAN-22 + KAN-31.
+- Fenêtre de disponibilité (`availability_from`, `availability_to`) : dates seulement (cohérent avec décision produit 2026-05-01 « Dates seulement au MVP »). Hors fenêtre, le produit est exclu du catalogue acheteur (logique de gating ajoutée dans `products_select_public`).
+- La maquette PR-04 affiche des compteurs « Envies / Vendus » par produit : ces stats sont **hors scope** (envies → KAN-30, ventes → KAN-19/27). Au MVP de KAN-20, ces blocs sont rendus avec `—` ou retirés.
+- Catégories : enum dur en DB (8 valeurs), aligné sur le `select` du form. KAN-24 pourra étendre vers une table `categories` si besoin (post-MVP).
+- Labels : stockés en `text[]` au MVP de KAN-20 pour contourner l'impossibilité Postgres de créer un enum vide ; KAN-24 swap colonne → enum dans sa propre migration.
+- Pas d'event Inngest émis depuis ce ticket. Les hooks de cache (opportunités, etc.) seront mis en place quand le module qui les consomme arrivera, pour éviter de créer un event mort.

--- a/specs/KAN-20/tasks.md
+++ b/specs/KAN-20/tasks.md
@@ -1,0 +1,44 @@
+# Tâches techniques internes — KAN-20 Création & édition produit
+
+> Ces tâches ne sont pas dans Jira. Setup, migrations, refacto, helpers partagés, seeds, configuration — tout ce qui n'a pas vocation à être tracké comme livrable produit.
+>
+> Subtasks Jira existantes (rappel — ne pas dupliquer ici) :
+> - KAN-69 — Créer un produit (nom, description, catégorie, prix net, stock, fenêtre de dispo)
+> - KAN-70 — Modifier les informations d'un produit existant
+> - KAN-71 — Supprimer un produit du catalogue
+
+## Tâches
+
+- [ ] Migration `supabase/migrations/20260518xxxxxx_create_products.sql` :
+  - [ ] ENUM `product_category` (8 valeurs)
+  - [ ] ENUM `product_packaging` (8 valeurs)
+  - [ ] ENUM `product_status` (`active`, `draft`, `disabled`)
+  - [ ] Table `products` avec colonnes, CHECK, defaults, `search_vector` généré (`to_tsvector('french', coalesce(name,'')||' '||coalesce(description,''))`)
+  - [ ] Index `(producer_user_id, status) WHERE deleted_at IS NULL`
+  - [ ] Index GIN sur `search_vector`
+  - [ ] Trigger `set_updated_at` BEFORE UPDATE
+  - [ ] RLS enable + policies `products_select_owner`, `products_select_public`, `products_insert_owner`, `products_update_owner`
+- [ ] Suppression du placeholder `supabase/policies/products.sql` (sa raison d'être disparaît) — dans la même migration / PR
+- [ ] Schemas Zod `packages/contracts/src/product/{create,update,list,snapshot}.ts` + export depuis `packages/contracts/src/product/index.ts` + index racine
+- [ ] Use cases core dans `packages/core/src/product/` : `create-product.ts`, `update-product.ts`, `soft-delete-product.ts`, `list-owner-products.ts`, `get-owner-product.ts` + erreurs typées dans `errors.ts`
+- [ ] Repo `packages/db/src/products/repo.ts` (`create`, `findById`, `findByOwner` avec filtres, `update`, `softDelete`) + factory `getProductsRepo()`
+- [ ] Adapter web `getProductAdapter()` dans `apps/web/lib/products/adapter.ts`
+- [ ] Route handlers `apps/web/app/api/v1/producer/products/route.ts` (GET + POST), `…/[id]/route.ts` (GET + PATCH + DELETE)
+- [ ] Page `apps/web/app/producer/catalogue/page.tsx` (liste, filtres, recherche, vide state)
+- [ ] Page `apps/web/app/producer/catalogue/nouveau/page.tsx` (form mode `new`)
+- [ ] Page `apps/web/app/producer/catalogue/[id]/page.tsx` (form mode `edit` + bouton suppression)
+- [ ] Composants `apps/web/components/producer/catalogue/` : `CatalogueList`, `CatalogueFilters`, `ProductCard`, `ProductForm`, `ProductFormPreview`, `ProductDeleteConfirm`
+- [ ] Sidebar producteur (`apps/web/components/producer/sidebar.tsx`) : activer le lien « Catalogue » (déjà dans le markup) + badge dynamique « Produits actifs » optionnel
+- [ ] Tests unitaires `packages/core/src/product/*.test.ts` (use cases) + `packages/contracts/src/product/*.test.ts` (Zod)
+- [ ] Tests E2E `apps/web/e2e/producer-catalogue.spec.ts` (5 scénarios listés dans design.md)
+- [ ] Tests RLS DB : différés tant que la CI Supabase locale n'est pas activée (cohérent KAN-17)
+- [ ] Seed dev `supabase/seeds/products-sample.sql` (optionnel — 3 à 5 produits sur le producteur de test) — différé si bloque pas la livraison
+- [ ] **Décision technique structurante à journaliser** dans ARCHITECTURE.md §18 :
+  - Création de la table `products` (premier objet catalogue côté DB)
+  - Pattern enum vide → `text[]` au MVP de KAN-20, swap par KAN-24 (à documenter pour ne pas reproduire)
+  - Suppression du placeholder `supabase/policies/products.sql` (introduit par KAN-16, levé par KAN-20)
+- [ ] Mise à jour `produit/jira_mapping.md` : ligne KAN-20 (statut, mention `[Cadrage tech](specs/KAN-20/)`), entrée "État au YYYY-MM-DD"
+
+## Checklist pre-merge
+
+Voir ARCHITECTURE.md §14.3 — ne pas dupliquer ici.


### PR DESCRIPTION
## Cadrage technique — KAN-20 Création & édition produit

Trois fichiers courts pour préparer l'implémentation du CRUD catalogue producteur :

- [`specs/KAN-20/proposal.md`](specs/KAN-20/proposal.md) — périmètre, in/out of scope, hypothèses (notamment le découpage propre vis-à-vis de KAN-21 photos, KAN-22 stock & alertes, KAN-23 statuts, KAN-24 labels)
- [`specs/KAN-20/design.md`](specs/KAN-20/design.md) — schéma table `products` (enums, FTS, RLS owner + public conditionnel), endpoints `/api/v1/producer/products`, UI PR-04/PR-05
- [`specs/KAN-20/tasks.md`](specs/KAN-20/tasks.md) — tâches techniques internes (migration, repo, use cases, pages, composants)

Synchro mapping : `produit/jira_mapping.md` mis à jour (table catalogue Jira + cellules PR-04/PR-05 + état au 2026-05-18).

Côté Jira : commentaire posé sur KAN-20 + section « Cadrage technique » ajoutée à la description (liens vers les 3 fichiers). Pas de transition à ce stade — `Ideas → À faire` se déclenche au merge de cette PR.

Subtasks Jira existantes pour mémoire (non dupliquées dans `tasks.md`) :
- KAN-69 — Créer un produit (nom, description, catégorie, prix net, stock, fenêtre de dispo)
- KAN-70 — Modifier les informations d'un produit existant
- KAN-71 — Supprimer un produit du catalogue

Décisions techniques structurantes proposées (à journaliser dans ARCHITECTURE.md §18 à l'implémentation, pas dans cette PR cadrage) :
- Création de la table `products` (premier objet catalogue côté DB)
- Pattern « enum vide → `text[]` au MVP » pour `labels` (swap par KAN-24)
- Suppression du placeholder `supabase/policies/products.sql` (sa raison d'être disparaît avec la migration KAN-20)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZGwf7BLrCeBUnUuphH7Gq)_