### PR TITLE
specs KAN-21 — Gestion photos

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -9,7 +9,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 - **13 épics** (KAN-1, KAN-4 → KAN-15) — un épic par grand domaine fonctionnel
 - **50 features cataloguées** (KAN-2, KAN-3 sous KAN-1 ; KAN-16 → KAN-158 sous les autres épics — voir tables par épic ci-dessous)
 - **Subtasks** : voir le catalogue par épic ci-dessous. Le mapping peut être incomplet pour les subtasks les plus récentes — Jira fait foi pour la liste exhaustive.
-- État au 2026-05-18 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-17 *Terminé* (mergé sur `main` — PR #18, cadrage `specs/KAN-17/`) ; KAN-18 *Terminé* (mergé sur `main` — PR #21, cadrage `specs/KAN-18/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; KAN-19 *Examiner* (mergé sur `main` — PR #25, cadrage `specs/KAN-19/`) ; KAN-20 *Examiner* (mergé sur `main` — PR #30, cadrage `specs/KAN-20/`) ; autres *Ideas*
+- État au 2026-05-18 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-17 *Terminé* (mergé sur `main` — PR #18, cadrage `specs/KAN-17/`) ; KAN-18 *Terminé* (mergé sur `main` — PR #21, cadrage `specs/KAN-18/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; KAN-19 *Examiner* (mergé sur `main` — PR #25, cadrage `specs/KAN-19/`) ; KAN-20 *Examiner* (mergé sur `main` — PR #30, cadrage `specs/KAN-20/`) ; KAN-21 *Ideas* (cadrage en cours — `specs/KAN-21/`) ; autres *Ideas*
 - **Maquettes (2026-05-14)** : les 35 écrans des 3 parcours (Producteur, Acheteur, Rameneur) du sitemap PRD §10 sont maquettés. Restent à maquetter : transverses **TR-02** (centre notifications) et **TR-04** (signalement / litige) ; **TR-03** est couvert par `rm-09-chat.html`. Index navigable de toutes les maquettes : `design/maquettes/index.html`
 
 ## Convention de référencement
@@ -31,7 +31,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | PR-02 Onboarding Stripe Connect | `pr-02-onboarding-stripe.html` | KAN-16 (Onboarding Stripe Connect) — [Cadrage tech](specs/KAN-16/) | KAN-62, KAN-158 (polish UX restricted) |
 | PR-03 Dashboard | `pr-03-dashboard.html` | KAN-18 (Tableau de bord producteur) — [Cadrage tech](specs/KAN-18/) | KAN-56 |
 | PR-04 Catalogue produits | `pr-04-catalogue.html` | KAN-20 (Création & édition produit) — [Cadrage tech](specs/KAN-20/) | KAN-23 (Statuts produit) |
-| PR-05 Création / édition produit | `pr-05-edition-produit.html` | KAN-20 (Création & édition produit) — [Cadrage tech](specs/KAN-20/) | KAN-21 (Photos), KAN-22 (Stock), KAN-24 (Labels & catégories) |
+| PR-05 Création / édition produit | `pr-05-edition-produit.html` | KAN-20 (Création & édition produit) — [Cadrage tech](specs/KAN-20/) | KAN-21 (Photos) — [Cadrage tech](specs/KAN-21/), KAN-22 (Stock), KAN-24 (Labels & catégories) |
 | PR-06 Récupération à venir | `pr-06-recuperation.html` | KAN-46 (QR Pickup), KAN-47 (Checklist remise producteur) | KAN-45 |
 | PR-07 Historique ventes | `pr-07-historique-ventes.html` | KAN-19 (Historique ventes) — [Cadrage tech](specs/KAN-19/) | KAN-36 (Factures PDF) |
 | PR-08 Profil public producteur | `pr-08-profil-public.html` | KAN-17 (Informations profil & ferme) — [Cadrage tech](specs/KAN-17/) | KAN-53 (Profils publics & avis), KAN-63, KAN-64, KAN-65, KAN-66 |
@@ -118,7 +118,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 |--------|------|--------|--------|
 | KAN-5 | Epic | Ideas | Catalogue |
 | KAN-20 | Feature | Examiner | Création & édition produit — [Cadrage tech](specs/KAN-20/) — mergé sur main (PR #30) |
-| KAN-21 | Feature | Ideas | Gestion photos |
+| KAN-21 | Feature | Ideas | Gestion photos — [Cadrage tech](specs/KAN-21/) |
 | KAN-22 | Feature | Ideas | Stock & alertes |
 | KAN-23 | Feature | Ideas | Statuts produit |
 | KAN-24 | Feature | Ideas | Labels & catégories |

--- a/specs/KAN-21/design.md
+++ b/specs/KAN-21/design.md
@@ -1,0 +1,170 @@
+# Conception technique — KAN-21 Gestion photos
+
+## Vue d'ensemble
+
+Un seul mouvement : connecter le pipeline Storage déjà battu par KAN-17 (`producer-photos`) au bucket frère `product-photos`, et câbler les invariants côté DB (`photos jsonb`, max 4, `photos[0] = couverture`) à l'UI déjà dessinée dans PR-05 mais désactivée par KAN-20.
+
+Pas de nouvelle table, pas de nouvelle colonne — l'infrastructure DB est posée. La seule migration nécessaire crée les policies RLS Storage du bucket `product-photos` (4 policies miroir de `producer-photos`) et aligne la config du bucket via `INSERT INTO storage.buckets … ON CONFLICT DO UPDATE`. Côté code, le pattern POST signature + PUT direct + persistance DB est reproduit, avec une nuance : les écritures de `photos` se font par endpoints dédiés (POST confirm / DELETE / PATCH reorder), pas via le PATCH produit général.
+
+## Packages touchés
+
+- [x] `packages/contracts` — `product/photos.ts` (Zod : upload, confirm, delete, reorder ; types `ProductPhotoMime`, `ProductPhotoEntry`)
+- [x] `packages/core` — `product/photos/` : use cases `addProductPhoto`, `removeProductPhoto`, `reorderProductPhotos` + erreurs typées (`PRODUCT_PHOTO_LIMIT_REACHED`, `PRODUCT_PHOTO_NOT_FOUND`, `PRODUCT_PHOTO_INVALID_REORDER`, `PRODUCT_PHOTO_MIME_REJECTED`)
+- [x] `packages/db` — extension du repo `products` : `appendPhoto`, `removePhotoAt`, `reorderPhotos` (opérations DB pures, pas Storage)
+- [x] `apps/web` — `app/api/v1/producer/products/[id]/photos/route.ts` (POST signature + DELETE), `…/photos/confirm/route.ts` (POST), `…/photos/reorder/route.ts` (PATCH), `lib/storage/product-photos.ts`
+- [ ] `apps/mobile` — hors scope
+- [ ] `packages/jobs` — aucun job
+- [x] `supabase/migrations` — `20260518xxxxxx_create_product_photos_storage_policies.sql` (alignement bucket + 4 policies storage)
+- [x] `supabase/policies/storage.sql` — miroir documentaire (ajout du bloc `product-photos` après celui de `producer-photos`)
+- [ ] `packages/ui-web` — composants dans `apps/web/components/producer/catalogue/`, pas dans `packages/ui-web/` (cohérent KAN-17/20)
+
+## Modèle de données
+
+Aucun changement de schéma. Rappels :
+
+- Table `public.products`, colonne `photos jsonb NOT NULL DEFAULT '[]'::jsonb`.
+- CHECK `products_photos_max` : `jsonb_typeof(photos) = 'array' AND jsonb_array_length(photos) <= 4`.
+- Format applicatif du tableau (validé Zod côté contracts, pas en DB) :
+
+```ts
+type ProductPhotoEntry = {
+  url: string          // URL publique Storage (bucket product-photos public)
+  path: string         // Path complet dans le bucket — utilisé au DELETE Storage
+  alt?: string         // optionnel, vide au MVP
+}
+type Photos = ProductPhotoEntry[]  // 0..4 entries, photos[0] = couverture
+```
+
+- Pas de colonne `is_cover` : `photos[0]` fait foi par convention. Test unitaire core garantit que toute opération qui modifie le tableau préserve cette invariante.
+
+**Storage** :
+
+- Bucket `product-photos` (déjà créé via dashboard le 2026-05-08, cf. `tech/setup.md` ligne 25). Public en lecture, 5 MB max, MIME `image/{jpeg,png,webp}`.
+- Migration KAN-21 : `INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types) VALUES ('product-photos', 'product-photos', true, 5242880, ARRAY['image/jpeg','image/png','image/webp']) ON CONFLICT (id) DO UPDATE SET …` (idempotent, aligne la config dashboard si dérive).
+- Convention path : `{user_id}/{product_id}/<random8>.<ext>` (random short ID — voir Hypothèses dans proposal.md). Le 1ᵉʳ segment passe la `WITH CHECK` RLS.
+
+**Policies RLS Storage du bucket `product-photos`** (miroir de `producer-photos`) :
+
+| Policy | Opération | Cible | Condition |
+|---|---|---|---|
+| `product_photos_select_public` | SELECT | anon, authenticated | `bucket_id = 'product-photos'` |
+| `product_photos_insert_owner` | INSERT | authenticated | `bucket_id = 'product-photos' AND auth.uid()::text = (storage.foldername(name))[1]` |
+| `product_photos_update_owner` | UPDATE | authenticated | idem INSERT (USING + WITH CHECK) |
+| `product_photos_delete_owner` | DELETE | authenticated | idem INSERT |
+
+Note : la policy SELECT publique se justifie car le bucket est public (acheteurs anonymes voient les vignettes). L'isolement utilisateur est strictement côté write.
+
+Référence : ARCHITECTURE.md §5.2, §9.2 ; `supabase/migrations/20260517150000_extend_producers_profile.sql` lignes 314-355 (modèle KAN-17).
+
+## API / Endpoints
+
+Tous versionnés `/api/v1/`, validés Zod, handlers 15-30 lignes (ARCHITECTURE §3, §14.2). Auth : `requireProducerRole(user)`, vérif ownership du produit (RLS `products` filtrera de toute façon ; on inline un check explicite 404/403 pour la lisibilité).
+
+- `POST /api/v1/producer/products/[id]/photos`
+  - Input Zod `productPhotoUploadInput` : `{ content_type: 'image/jpeg' | 'image/png' | 'image/webp' }` (pas de `slot` — l'index est calculé serveur = `photos.length`).
+  - Vérifie `photos.length < 4` (sinon `PRODUCT_PHOTO_LIMIT_REACHED`, 409).
+  - Génère un random short ID (8 chars hex via `crypto.randomBytes(4).toString('hex')`), construit le path `{user_id}/{product_id}/<id>.<ext>`.
+  - Appelle `createSignedUploadUrl(path, { upsert: false })`.
+  - Renvoie `{ path, upload_url, public_url, token_expires_in: 60 }`.
+  - **Ne persiste pas encore** la photo dans `products.photos` — le client persistera après PUT réussi via l'endpoint `confirm`.
+
+- `POST /api/v1/producer/products/[id]/photos/confirm`
+  - Input Zod `productPhotoConfirmInput` : `{ path: string, public_url: string }`.
+  - Vérifie que `path` commence bien par `{auth.uid()}/{product_id}/` (anti-tampering basique).
+  - Use case `addProductPhoto` : append `{ url: public_url, path }` au tableau `photos` du produit (CHECK DB rattrape la race condition si deux uploads simultanés — handler catch sur Postgres `23514` → `PRODUCT_PHOTO_LIMIT_REACHED`).
+  - Renvoie le snapshot complet du produit.
+
+- `DELETE /api/v1/producer/products/[id]/photos`
+  - Input Zod `productPhotoDeleteInput` : `{ index: number }` (0..3).
+  - Use case `removeProductPhoto` : lit le `path` depuis `photos[index].path`, supprime le fichier Storage via `client.storage.from('product-photos').remove([path])` (tolère 404), retire l'entrée du tableau (réindexation auto par splice), renvoie le snapshot. Si le Storage remove échoue, on retourne quand même le snapshot DB mis à jour (le fichier devient orphelin — voir Risques).
+
+- `PATCH /api/v1/producer/products/[id]/photos/reorder`
+  - Input Zod `productPhotoReorderInput` : `{ from: number, to: number }`.
+  - Use case `reorderProductPhotos` : check bornes (`0 ≤ from < photos.length`, `0 ≤ to < photos.length`, `from ≠ to`), permute, renvoie snapshot. Aucun appel Storage.
+
+Erreurs typées (héritage `core/errors.ts`) :
+- `PRODUCT_PHOTO_LIMIT_REACHED` (409)
+- `PRODUCT_PHOTO_NOT_FOUND` (404 si `index ≥ photos.length`)
+- `PRODUCT_PHOTO_INVALID_REORDER` (400 si `from === to` ou bornes invalides)
+- `PRODUCT_PHOTO_MIME_REJECTED` (400, hérité de la validation Zod)
+- `PRODUCT_FORBIDDEN` (403, déjà défini KAN-20)
+- `PRODUCT_NOT_FOUND` (404, déjà défini KAN-20)
+
+## Impact state machine / events
+
+Aucun. Pas de transition mission, pas d'event Inngest (cohérent avec la note KAN-20 : `product.updated` reste théorique tant que KAN-42 ne consomme pas).
+
+## Dépendances
+
+Services externes :
+- **Supabase Storage** — bucket `product-photos` (`tech/setup.md` § Supabase ligne 25, provisionné 2026-05-08, public, 5 MB, MIME jpeg/png/webp). KAN-21 ajoute les policies RLS Storage via migration (rattrapage de la convention « bucket versionné » posée par KAN-17).
+- Aucune autre dépendance externe.
+
+Internes :
+- `apps/web/lib/storage/producer-photos.ts` (KAN-17) — modèle direct, factorisable mais on choisit de **dupliquer** dans `product-photos.ts` plutôt que d'abstraire prématurément. Si un 3ᵉ bucket apparaît (post-MVP), on extraira un helper générique. Trois similar lines is better than a premature abstraction (cf. CLAUDE.md).
+- Table `products` (KAN-20) — colonnes `photos`, CHECK `products_photos_max`.
+- Migration `20260517150000_extend_producers_profile.sql` — modèle des 4 policies storage (lignes 314-355).
+- Composants `<ProductForm />` et `<ProductFormPreview />` (KAN-20) — câblage final.
+
+## État UI
+
+Référence : DESIGN.md (tokens, breakpoints) ; maquette `pr-05-edition-produit.html` lue intégralement, section 2 « Photos du produit » (lignes 717-745).
+
+**Composant `<ProductPhotoUploader />`** (nouveau, dans `apps/web/components/producer/catalogue/photo-uploader.tsx`) :
+
+- Grille `display: grid; grid-template-columns: 1fr 1fr; gap: 14px;` (desktop). Responsive : 1 colonne < 540 px (cf. maquette ligne 555).
+- Affiche jusqu'à 4 slots :
+  - Slots remplis (`i < photos.length`) : preview `<img src={photos[i].url} className="object-cover">`, badge « Couverture » sur i=0 (`photo-cover-tag`), boutons d'action en overlay top-right : « ↑ », « ↓ » (reorder, désactivés en bord), « 🗑 » (delete, hover rouge).
+  - Slot vide suivant (`i === photos.length`) : zone dashed avec icône caméra + label « Ajouter une photo » (cf. maquette lignes 740-743). Clique → `<input type="file">`.
+  - Slots vides au-delà (`i > photos.length`) : non rendus (la maquette montre 4 slots fixes, mais on rend seulement `photos.length + 1` slots — moins de bruit visuel quand 0 ou 1 photo).
+- Pipeline upload : `<input file>` → validate MIME + size côté client (5 MB, jpeg/png/webp) → `POST /photos` (signature) → `PUT upload_url` avec `Content-Type` exact → `POST /photos/confirm`. État `busy` désactive tous les contrôles. Erreurs inline en `text-[#C0392B]` (pattern KAN-17).
+- Pipeline reorder : click ↑ → `PATCH /photos/reorder { from: i, to: i-1 }`. Optimistic update local + revalidation au retour.
+- Pipeline delete : click 🗑 → confirmation inline (« Supprimer ? Annuler ») → `DELETE /photos { index: i }`. Pas de modale (sécurité réversible par re-upload, opération non destructrice du produit).
+- Helper text au-dessus : « Une à 4 photos. La première sera utilisée comme couverture. Format paysage de préférence. » (extrait de la maquette ligne 724).
+
+**Câblage dans `<ProductForm />`** (KAN-20, `apps/web/components/producer/catalogue/product-form.tsx` ligne ~296) :
+
+- Retirer l'overlay `disabledBanner="Bientôt — KAN-21"` (lignes 296-326 du JSX actuel).
+- Monter `<ProductPhotoUploader productId={product.id} photos={product.photos} onChange={(updated) => setProduct({ ...product, photos: updated })} />`.
+- En mode « nouveau » (pas d'`id` encore) : afficher un message « Enregistrez d'abord le produit pour ajouter des photos » (le `productId` n'existe pas tant que le POST initial n'a pas eu lieu — cohérent avec le flow KAN-17 où le wizard crée la coquille avant d'autoriser l'upload).
+- Le PATCH général du produit n'écrit plus la clé `photos` — la sérialisation côté client retire ce champ avant l'envoi pour éviter toute désynchronisation.
+
+**Câblage dans `<ProductFormPreview />`** (KAN-20) :
+
+- Remplacer le `<span class="mock-card-emoji">🍯</span>` placeholder par `<img src={photos[0].url}>` quand `photos.length > 0`. Garder l'emoji fallback sinon.
+
+Mobile : non livré (cohérent KAN-17/18/20).
+
+## Risques techniques
+
+- **Fichiers orphelins Storage** : si le PUT direct réussit mais que le `POST /photos/confirm` échoue (réseau, crash navigateur, etc.), le fichier reste dans Storage sans être référencé dans `products.photos`. Inversement, si `removeProductPhoto` met à jour `photos` mais que le Storage `.remove()` échoue. **Au MVP, on accepte cette dette**. Mitigation post-MVP : job Inngest périodique qui liste les fichiers `product-photos/{user_id}/*/*` et croise avec `products.photos` côté DB ; supprime les orphelins > 24 h. À noter dans backlog.
+- **Race condition `photos.length`** : deux uploads quasi-simultanés peuvent passer la vérif `photos.length < 4` côté serveur avant le commit DB du premier. Le CHECK `products_photos_max` rattrape (la 5ᵉ ligne échoue avec un constraint violation). Bien gérer l'erreur DB côté handler `confirm` (catch sur code Postgres `23514`) et renvoyer `PRODUCT_PHOTO_LIMIT_REACHED` au lieu d'un 500.
+- **Convention path divergente vs KAN-17** : KAN-17 utilise `{user_id}/logo.<ext>` ou `{user_id}/farm-<slot>.<ext>` (chemins déterministes, upsert), KAN-21 utilise `{user_id}/{product_id}/<random>.<ext>` (chemins uniques). Différence assumée : photos de profil = remplaçables (un seul logo), photos produit = collection variable. Documenter dans le commentaire de `product-photos.ts`.
+- **`upsert: false` vs `upsert: true`** : KAN-17 utilise `upsert: true` pour permettre de remplacer le logo. KAN-21 utilise `upsert: false` car le path est unique par random ID — un `upsert: true` masquerait une collision (improbable mais possible). Rejeter explicitement.
+- **Bucket public + RGPD** : les URLs sont devinables si on connaît le user_id + product_id + l'ID court (8 hex = 4 milliards de combinaisons). Pas un secret cryptographique mais largement suffisant pour des photos de produits non sensibles. Aligné avec `producer-photos`.
+- **Limite free-tier Storage** : 1 GB de stockage et 2 GB de bande passante / mois sur le plan Free. 4 photos × 5 MB × ~50 producteurs = 1 GB. Surveiller le quota dashboard. Trigger d'upgrade documenté dans ARCHITECTURE.md §13.2.
+- **Pas de transformation** : si un producteur upload une photo 5000×4000 px à 4 MB, elle sera servie telle quelle à l'acheteur (bande passante consommée). Acceptable au MVP (producteurs ciblés ≤ 50). Note pour KAN-28 acheteur : envisager Vercel Image Optimization (`<Image src>` auto-WebP + resize) à ce moment.
+- **Anti-tampering du path côté `confirm`** : un client malveillant pourrait appeler `POST /photos/confirm` avec un path arbitraire (ex : pointant vers une photo d'un autre producteur). Le check `path.startsWith(`${auth.uid()}/${productId}/`)` côté handler bloque ce cas. RLS table `products` bloque de toute façon l'écriture sur un produit qui n'appartient pas à l'auteur.
+
+## Tests envisagés
+
+Référence : ARCHITECTURE.md §10.
+
+- **Unit `packages/contracts`** (`product/photos.test.ts`) :
+  - `productPhotoUploadInput` accepte `image/jpeg`, `png`, `webp`, refuse `image/gif`, `image/heic`.
+  - `productPhotoReorderInput` : `from` et `to` ≥ 0 et < 4, `from ≠ to`.
+  - `ProductPhotoEntry` exige `url` + `path`, accepte `alt` optionnel.
+- **Unit `packages/core/src/product/photos/`** :
+  - `addProductPhoto` : succès, refus si `photos.length === 4`, préservation des entrées existantes.
+  - `removeProductPhoto` : succès (réindexation par splice), refus si index hors bornes, préservation de `photos[0]` comme couverture quand on supprime un autre index.
+  - `reorderProductPhotos` : permutation correcte (from=2, to=0 → la photo passe en couverture), refus si index identiques ou hors bornes.
+- **Intégration DB** (différée tant que CI Supabase locale non activée, cohérent KAN-20) :
+  - CHECK `products_photos_max` rattrape un INSERT direct avec 5 entrées.
+  - Policy Storage `product_photos_insert_owner` rejette un upload avec un path commençant par un autre user_id.
+- **E2E web Playwright** (`apps/web/e2e/producer-catalogue.spec.ts` — étendre le fichier existant) :
+  - Producteur ouvre `/producer/catalogue/[id]`, ajoute une photo, voit la couverture dans la preview droite.
+  - Ajoute 4 photos, vérifie que le 5ᵉ slot disparaît.
+  - Réordonne (↑ sur photo 2), vérifie que la couverture change.
+  - Supprime la couverture, vérifie que la photo 2 devient couverture.
+  - **Différé** si fixtures auth producteur indisponibles, cohérent avec note KAN-20.
+- **Tests Storage policies** : différés (cohérent KAN-17 / KAN-20).

--- a/specs/KAN-21/proposal.md
+++ b/specs/KAN-21/proposal.md
@@ -1,0 +1,53 @@
+# Cadrage — KAN-21 Gestion photos
+
+## Liens
+
+- Jira : https://erkulaws.atlassian.net/browse/KAN-21
+- Epic : KAN-5 Catalogue
+- Maquette : `design/maquettes/producteur/pr-05-edition-produit.html` (section 2 « Photos du produit » — actuellement désactivée par KAN-20)
+- PRD : §10.2 PR-05 Création / édition produit
+- ARCHITECTURE : §5 (DB — colonne `photos jsonb` déjà présente, bucket `product-photos`), §9 (RLS Storage), §13 (free-tier Storage), §14 (playbook), §18 entrée 1.19 (pattern photos producteur posé par KAN-17), §18 entrée 1.22 (CHECK `products_photos_max` déjà en DB)
+
+## Pourquoi (côté tech)
+
+KAN-20 a livré la table `products` avec la colonne `photos jsonb NOT NULL DEFAULT '[]'` plafonnée à 4 entrées par un CHECK (`products_photos_max`), et le bucket Storage `product-photos` est provisionné depuis le 2026-05-08 (cf. `tech/setup.md` § Supabase ligne 25). Le formulaire d'édition (PR-05 section 2) affiche pour l'instant un overlay « Bientôt — KAN-21 » sur la zone d'upload.
+
+KAN-21 active réellement cette section : pipeline d'upload signé identique à KAN-17 (`producer-photos`), persistance ordonnée des URLs dans `products.photos`, gestion d'une couverture (1ʳᵉ photo), réorganisation et suppression par photo. Aucun nouveau bucket, aucune nouvelle colonne — c'est purement câbler le contenant à l'écran.
+
+## Périmètre technique
+
+**In scope :**
+
+- Policies RLS Storage du bucket `product-photos` (le bucket existe déjà mais ses policies n'ont jamais été versionnées via migration — KAN-17 a posé celles de `producer-photos`, on étend le même pattern). Convention de path : `{auth_user_id}/{product_id}/<random8>.<ext>`. Premier segment = `auth.uid()::text` pour passer `WITH CHECK`.
+- Alignement de la config du bucket via `INSERT INTO storage.buckets … ON CONFLICT DO UPDATE` dans la même migration (convention « bucket versionné » posée par KAN-17 le 2026-05-17). Idempotent.
+- Endpoint `POST /api/v1/producer/products/[id]/photos` → vérifie owner + producteur, valide MIME, vérifie `photos.length < 4`, génère URL signée d'upload via `client.storage.from('product-photos').createSignedUploadUrl(path, { upsert: false })`. Renvoie `{ path, upload_url, public_url, token_expires_in }`. Ne persiste rien en DB.
+- Endpoint `POST /api/v1/producer/products/[id]/photos/confirm` → body `{ path, public_url }` ; persiste `{ url, path }` au tableau `photos` via le use case `addProductPhoto`. Renvoie le snapshot complet du produit.
+- Endpoint `DELETE /api/v1/producer/products/[id]/photos` → body `{ index: number }` ; supprime le fichier Storage (via `path` stocké dans le tuple) + retire l'entrée du tableau en réindexant les suivantes.
+- Endpoint `PATCH /api/v1/producer/products/[id]/photos/reorder` → body `{ from, to }` ; permute les entrées (couverture = `photos[0]`). Aucun appel Storage.
+- Use cases core dans `packages/core/src/product/photos/` : `addProductPhoto`, `removeProductPhoto`, `reorderProductPhotos` — modélisent les invariants (max 4, indices contigus, format `{ url, path, alt? }`).
+- Schémas Zod dans `packages/contracts/src/product/photos.ts` : `ProductPhotoMime`, `ProductPhotoEntry`, `productPhotoUploadInput`, `productPhotoUploadOutput`, `productPhotoConfirmInput`, `productPhotoDeleteInput`, `productPhotoReorderInput`. Le whitelist MIME (jpeg/png/webp) et la limite 5 MB sont identiques aux photos producteur — pas de partage de type avec `producer`, on duplique.
+- Helper Storage `apps/web/lib/storage/product-photos.ts` (miroir de `producer-photos.ts`) : `buildProductPhotoPath(userId, productId, randomId, mime)`, `createProductPhotoUploadUrl(client, …)`, `deleteProductPhoto(client, path)`. Ce helper reste local à `apps/web` au MVP (cohérent KAN-17, pas de réutilisation cross-app).
+- Composant `<ProductPhotoUploader />` dans `apps/web/components/producer/catalogue/` : grille 2×2 (responsive 1 col < 540 px, cf. maquette), slot couverture marqué `photo-cover-tag`, actions « ↑ », « ↓ », « 🗑 » au survol, état chargement, gestion d'erreur inline. Pas de drag-and-drop au MVP — les flèches haut/bas suffisent (PATCH reorder à chaque mouvement).
+- Câblage dans `<ProductForm />` (KAN-20) : retirer l'overlay « Bientôt — KAN-21 », monter `<ProductPhotoUploader productId={…} photos={form.photos} onChange={…} />` à la place. Les endpoints dédiés font autorité sur l'écriture de `photos` ; le PATCH général du produit n'écrit plus cette colonne.
+- Section preview droite (`<ProductFormPreview />`) : l'emoji catégorie placeholder est remplacé par `<img src={photos[0].url}>` quand au moins une photo est uploadée.
+- Tests unitaires des use cases core + tests Zod + 1 scénario E2E Playwright « ajouter, réorganiser, supprimer une photo » (déféré si fixtures auth producteur non disponibles, cohérent KAN-20).
+
+**Out of scope (cette US) :**
+
+- **Drag-and-drop** réordonnement libre : KAN-21 livre les flèches up/down ; un drag-and-drop avec `react-dnd` ou natif est reporté post-MVP.
+- **Compression / redimensionnement côté serveur** : non livré au MVP. Le format paysage est suggéré dans l'UI (« Format paysage de préférence ») mais aucune transformation n'est appliquée. Une étape Sharp + Vercel Image Optimization est notée en Risques mais hors livraison.
+- **Génération d'`alt` automatique** : le champ `alt` du tuple reste vide au MVP — pas de champ UI ni de génération AI. Réservé v2.
+- **Transactions atomiques DB + Storage** : on accepte qu'un upload Storage réussi puis un POST `confirm` qui échoue laisse un fichier orphelin (et inversement). Un cron de réconciliation pourra être ajouté post-MVP (cf. Risques).
+- **Catalogue acheteur (KAN-28)** : la consommation des URLs publiques côté acheteur est différée. KAN-21 garantit juste que `photos[0].url` est lisible publiquement (bucket public + policy SELECT anon).
+- **Mobile** : non livré (`apps/mobile/` reste non scaffoldé, cohérent avec l'épic KAN-5).
+
+## Hypothèses
+
+- Le bucket `product-photos` est déjà provisionné en mode **public**, 5 MB max, MIME `image/jpeg/png/webp` (cf. `tech/setup.md` ligne 25). Aucune création de bucket via migration nécessaire — seules les policies RLS Storage doivent être versionnées (le bucket a été créé via dashboard à l'init, avant la convention « bucket versionné par migration » posée par KAN-17). Migration KAN-21 = `INSERT INTO storage.buckets … ON CONFLICT DO UPDATE` pour aligner la config + 4 policies.
+- La convention de path `{user_id}/{product_id}/<random8>.<ext>` permet à la RLS Storage de gérer l'autorisation sans connaître la table `products` (vérif uniquement `auth.uid()::text = foldername[1]`). L'appartenance produit → producteur est garantie par la RLS de la table `products` qui filtre déjà au niveau des endpoints. On accepte qu'un producteur puisse théoriquement uploader dans le dossier d'un produit qui ne lui appartient pas s'il devine l'UUID — mais (a) le `POST /photos/confirm` qui persisterait l'URL est bloqué par RLS `products_update_owner`, (b) l'URL publique reste inaccessible côté acheteur tant qu'elle n'est pas référencée dans `photos`. Risque résiduel = pollution Storage, accepté.
+- Limite « 4 photos max » : enforced à 3 niveaux — UI (4 slots), serveur (check `photos.length < 4` avant signature), DB (`products_photos_max` CHECK `jsonb_array_length ≤ 4`). Le CHECK DB rattrape la race condition d'uploads concurrents (cf. Risques techniques dans design.md).
+- `photos[0]` = couverture, par convention d'ordre du tableau. Aucune colonne `is_cover` séparée — la première position fait foi. Cohérent avec la maquette qui affiche le badge « Couverture » sur le premier slot.
+- L'écriture finale de `photos jsonb` passe par les **endpoints dédiés** (`POST confirm`, `DELETE`, `PATCH reorder`), pas par le PATCH général du produit. Cela évite qu'un PATCH product « tout-en-un » soumette un `photos` désynchronisé du Storage. Le `<ProductForm />` reflète l'état serveur après chaque action photo.
+- Le tuple stocké en DB est `{ url, path, alt? }` et non juste `{ url, alt? }`. Le `path` redondant supprime la fragilité du reparsing d'URL au DELETE Storage. Coût négligeable (~ 60 octets supplémentaires par photo).
+- Le path Storage utilise un **random short ID** (8 chars hex) plutôt qu'un index positionnel `<n>.<ext>`. Cela évite tout rename Storage à la réindexation (DELETE / REORDER ne touchent que la DB, les fichiers sont écrasés uniquement à l'ajout). Décision retenue.
+- Le bucket reste **public** : pas d'URL signée à la lecture (les acheteurs accèdent via `<img src>`). Aligné avec `producer-photos` (KAN-17) — décision identique, on ne change pas le compromis.

--- a/specs/KAN-21/tasks.md
+++ b/specs/KAN-21/tasks.md
@@ -1,0 +1,66 @@
+# Tâches techniques internes — KAN-21 Gestion photos
+
+> Ces tâches ne sont pas dans Jira. Setup, migrations, refacto, helpers partagés, seeds, configuration — tout ce qui n'a pas vocation à être tracké comme livrable produit.
+>
+> Subtasks Jira existantes (rappel — ne pas dupliquer ici) :
+> (aucune au moment du cadrage — la feature n'a pas encore été éclatée en subtasks Jira)
+
+## Tâches
+
+- [ ] Migration `supabase/migrations/20260518xxxxxx_create_product_photos_storage_policies.sql` :
+  - [ ] `INSERT INTO storage.buckets … ON CONFLICT (id) DO UPDATE` pour aligner config bucket `product-photos` (public, 5242880, MIME jpeg/png/webp) — convention KAN-17
+  - [ ] 4 policies storage : `product_photos_select_public`, `product_photos_insert_owner`, `product_photos_update_owner`, `product_photos_delete_owner` (miroir de `producer-photos`, segment 1 du path = `auth.uid()::text`)
+  - [ ] DROP POLICY IF EXISTS avant chaque CREATE pour rendre la migration idempotente
+- [ ] Mise à jour `supabase/policies/storage.sql` (miroir documentaire) — ajouter le bloc `product-photos` après le bloc `producer-photos`. Rappel : ce fichier est purement documentaire, la source de vérité reste la migration.
+- [ ] Schémas Zod `packages/contracts/src/product/photos.ts` :
+  - [ ] `ProductPhotoMime` (`'image/jpeg' | 'image/png' | 'image/webp'`)
+  - [ ] `ProductPhotoEntry` (`{ url: string, path: string, alt?: string }`) — **important** : `path` est stocké en plus de `url` pour éviter le reparsing fragile au DELETE (cf. design.md Risques)
+  - [ ] `productPhotoUploadInput`, `productPhotoUploadOutput`, `productPhotoConfirmInput`, `productPhotoDeleteInput`, `productPhotoReorderInput`
+  - [ ] Export depuis `packages/contracts/src/product/index.ts` + racine
+- [ ] Mettre à jour `packages/contracts/src/product/{create,update,snapshot}.ts` pour intégrer `ProductPhotoEntry` dans le tuple `photos` (au lieu d'un placeholder vide hérité de KAN-20)
+- [ ] Use cases core `packages/core/src/product/photos/` :
+  - [ ] `add-product-photo.ts` + test
+  - [ ] `remove-product-photo.ts` + test (réindexation par splice, préservation couverture)
+  - [ ] `reorder-product-photos.ts` + test (bornes, permutation, couverture)
+  - [ ] Erreurs typées dans `packages/core/src/errors.ts` : `PRODUCT_PHOTO_LIMIT_REACHED`, `PRODUCT_PHOTO_NOT_FOUND`, `PRODUCT_PHOTO_INVALID_REORDER`, `PRODUCT_PHOTO_MIME_REJECTED`
+- [ ] Repo `packages/db/src/products/repo.ts` : ajout `appendPhoto(productId, entry)`, `removePhotoAt(productId, index)`, `reorderPhotos(productId, from, to)` (opérations DB pures, pas Storage)
+- [ ] Helper Storage `apps/web/lib/storage/product-photos.ts` (miroir de `producer-photos.ts`) :
+  - [ ] `buildProductPhotoPath(userId, productId, randomId, mime)` — convention `{user_id}/{product_id}/<random8>.<ext>`
+  - [ ] `createProductPhotoUploadUrl(client, userId, productId, input)` → `{ path, upload_url, public_url, token_expires_in }`
+  - [ ] `deleteProductPhoto(client, path)` → `client.storage.from('product-photos').remove([path])` (tolère 404, ne throw pas)
+  - [ ] Génération random short ID : 8 chars hex via `crypto.randomBytes(4).toString('hex')`
+  - [ ] Documenter en tête du fichier la différence de convention vs `producer-photos.ts` (path random vs déterministe, upsert false vs true)
+- [ ] Route handlers :
+  - [ ] `apps/web/app/api/v1/producer/products/[id]/photos/route.ts` (POST signature + DELETE remove)
+  - [ ] `apps/web/app/api/v1/producer/products/[id]/photos/confirm/route.ts` (POST persiste DB après PUT direct, catch Postgres `23514` → `PRODUCT_PHOTO_LIMIT_REACHED`)
+  - [ ] `apps/web/app/api/v1/producer/products/[id]/photos/reorder/route.ts` (PATCH)
+  - [ ] Tous les handlers : check `requireProducerRole` + check `productExists && product.producer_user_id === user.id` (helper à inliner ou factoriser depuis les routes KAN-20)
+- [ ] Composant `apps/web/components/producer/catalogue/photo-uploader.tsx` :
+  - [ ] Grille 2×2 responsive, slots avec badges/actions selon design.md
+  - [ ] Pipeline upload (validate MIME + size côté client → POST signature → PUT direct → POST confirm)
+  - [ ] Pipeline reorder (boutons ↑/↓ avec PATCH, optimistic update)
+  - [ ] Pipeline delete (confirmation inline + DELETE)
+  - [ ] Gestion `busy` et erreurs inline (pattern KAN-17)
+- [ ] Modifier `apps/web/components/producer/catalogue/product-form.tsx` :
+  - [ ] Retirer l'overlay `disabledBanner="Bientôt — KAN-21"` (lignes ~296-326)
+  - [ ] Monter `<ProductPhotoUploader />` avec props `productId`, `photos`, `onChange`
+  - [ ] En mode « nouveau » : afficher message « Enregistrez d'abord le produit pour ajouter des photos »
+  - [ ] Retirer la clé `photos` du payload PATCH général (sérialisation client) — les endpoints dédiés font autorité
+- [ ] Modifier `apps/web/components/producer/catalogue/product-form-preview.tsx` :
+  - [ ] Remplacer emoji placeholder par `<img src={photos[0].url}>` quand `photos.length > 0`
+- [ ] Tests :
+  - [ ] Unit contracts (`photos.test.ts`) — couvre MIME, reorder bornes, ProductPhotoEntry
+  - [ ] Unit core (3 use cases × ~5 scénarios chacun)
+  - [ ] E2E Playwright différés cohérent KAN-17/20 (mais étendre `producer-catalogue.spec.ts` avec les scénarios définis dans design.md, prêts à activer dès que la fixture auth producteur arrive)
+- [ ] Vérifier l'idempotence de la migration (`DROP POLICY IF EXISTS` + `ON CONFLICT`) pour pouvoir relancer `supabase db push` sans erreur.
+- [ ] **Décision technique à journaliser** dans ARCHITECTURE.md §18 (dans le commit d'implémentation, pas dans le commit de cadrage) :
+  - Activation du bucket `product-photos` (alignement config + 4 policies storage) — 2ᵉ bucket versionné, confirme la convention KAN-17
+  - Pattern « path random ID + entry `{url, path, alt?}` en DB » (distinct de `producer-photos` qui utilise des paths déterministes) — décision retenue pour fragilité au DELETE
+  - Pattern « endpoints photo dédiés + PATCH produit n'écrit pas `photos` » — séparation responsabilité Storage / metadata
+- [ ] Mise à jour `produit/jira_mapping.md` :
+  - [ ] Ligne KAN-21 dans la table KAN-5 — mention `[Cadrage tech](specs/KAN-21/)` (statut reste `Ideas` jusqu'au merge)
+  - [ ] Section « Vue d'ensemble » : entrée État au YYYY-MM-DD avec KAN-21 en *Ideas (cadrage)*
+
+## Checklist pre-merge
+
+Voir ARCHITECTURE.md §14.3 — ne pas dupliquer ici.


### PR DESCRIPTION
## Cadrage technique KAN-21 — Gestion photos

Ouverture du cadrage technique pour [KAN-21](https://erkulaws.atlassian.net/browse/KAN-21) (épic [KAN-5 Catalogue](https://erkulaws.atlassian.net/browse/KAN-5)). Active la section « Photos du produit » de PR-05, désactivée par KAN-20.

### Contenu

- `specs/KAN-21/proposal.md` — périmètre, in/out scope, hypothèses
- `specs/KAN-21/design.md` — modèle de données (aucun changement schéma — réutilise `products.photos jsonb`), endpoints, policies storage, état UI, risques techniques
- `specs/KAN-21/tasks.md` — tâches techniques internes (migration storage policies, helper Storage, composant uploader, câblage `<ProductForm />`)

### Points saillants

- **Aucune nouvelle table, aucune nouvelle colonne** : la colonne `photos jsonb` et le CHECK `products_photos_max` sont déjà posés par KAN-20 ; le bucket `product-photos` est provisionné depuis le 2026-05-08.
- **Une seule migration** : alignement config du bucket via `INSERT … ON CONFLICT DO UPDATE` + 4 policies storage miroir de `producer-photos` (KAN-17).
- **Tuple DB enrichi** `{ url, path, alt? }` — `path` redondant pour éviter le reparsing fragile au DELETE Storage.
- **Path Storage random** (`{user_id}/{product_id}/<random8>.<ext>`) — évite les renames Storage à la réindexation, divergent de `producer-photos` (paths déterministes) — assumé.
- **Endpoints dédiés** (`POST signature` / `POST confirm` / `DELETE` / `PATCH reorder`) — le PATCH général du produit n'écrit plus `photos`, séparation des responsabilités Storage / DB.
- **Pipeline 4 étapes** : POST signature → PUT direct vers Storage → POST confirm → revalidation. Pattern reproduit de KAN-17.

### Synchronisations

- `produit/jira_mapping.md` : ligne KAN-21 enrichie du lien cadrage, vue d'ensemble mise à jour
- Jira KAN-21 : commentaire de cadrage + section « Cadrage technique » ajoutée à la description, pas de transition (reste `Ideas` jusqu'au merge)

### Suite

À la fusion : transition Jira `Ideas → À faire`, mise à jour mapping, désabonnement, et enchaînement automatique sur `/implement KAN-21`.


---
_Generated by [Claude Code](https://claude.ai/code/session_016VGdVBWktLN5YdxZW6SjD3)_