### PR TITLE
[KAN-22] ouverture cadrage

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -31,7 +31,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | PR-02 Onboarding Stripe Connect | `pr-02-onboarding-stripe.html` | KAN-16 (Onboarding Stripe Connect) — [Cadrage tech](specs/KAN-16/) | KAN-62, KAN-158 (polish UX restricted) |
 | PR-03 Dashboard | `pr-03-dashboard.html` | KAN-18 (Tableau de bord producteur) — [Cadrage tech](specs/KAN-18/) | KAN-56 |
 | PR-04 Catalogue produits | `pr-04-catalogue.html` | KAN-20 (Création & édition produit) — [Cadrage tech](specs/KAN-20/) | KAN-23 (Statuts produit) |
-| PR-05 Création / édition produit | `pr-05-edition-produit.html` | KAN-20 (Création & édition produit) — [Cadrage tech](specs/KAN-20/) | KAN-21 (Photos) — [Cadrage tech](specs/KAN-21/), KAN-22 (Stock), KAN-24 (Labels & catégories) |
+| PR-05 Création / édition produit | `pr-05-edition-produit.html` | KAN-20 (Création & édition produit) — [Cadrage tech](specs/KAN-20/) | KAN-21 (Photos) — [Cadrage tech](specs/KAN-21/), KAN-22 (Stock) — [Cadrage tech](specs/KAN-22/), KAN-24 (Labels & catégories) |
 | PR-06 Récupération à venir | `pr-06-recuperation.html` | KAN-46 (QR Pickup), KAN-47 (Checklist remise producteur) | KAN-45 |
 | PR-07 Historique ventes | `pr-07-historique-ventes.html` | KAN-19 (Historique ventes) — [Cadrage tech](specs/KAN-19/) | KAN-36 (Factures PDF) |
 | PR-08 Profil public producteur | `pr-08-profil-public.html` | KAN-17 (Informations profil & ferme) — [Cadrage tech](specs/KAN-17/) | KAN-53 (Profils publics & avis), KAN-63, KAN-64, KAN-65, KAN-66 |
@@ -119,7 +119,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | KAN-5 | Epic | Ideas | Catalogue |
 | KAN-20 | Feature | Examiner | Création & édition produit — [Cadrage tech](specs/KAN-20/) — mergé sur main (PR #30) |
 | KAN-21 | Feature | Examiner | Gestion photos — [Cadrage tech](specs/KAN-21/) — mergé sur main (PR #34) |
-| KAN-22 | Feature | Ideas | Stock & alertes |
+| KAN-22 | Feature | Ideas | Stock & alertes — [Cadrage tech](specs/KAN-22/) |
 | KAN-23 | Feature | Ideas | Statuts produit |
 | KAN-24 | Feature | Ideas | Labels & catégories |
 

--- a/specs/KAN-22/design.md
+++ b/specs/KAN-22/design.md
@@ -1,0 +1,121 @@
+# Conception technique — KAN-22 Stock & alertes
+
+## Vue d'ensemble
+
+KAN-22 est un câblage applicatif sans migration. La colonne `low_stock_threshold` posée par KAN-20 est propagée à travers les schémas Zod, les use cases, le repo, l'adapter web, et le formulaire. En parallèle, un helper d'affichage pur dérive l'état stock (`ok` / `low` / `empty`) à partir du couple `(stock, low_stock_threshold, status)` et alimente les badges de la card produit (PR-04) et du panneau preview (PR-05).
+
+Pas de state machine, pas d'event Inngest, pas de DB change. Le mouvement principal est la propagation d'un champ existant + une logique d'affichage pure. Toute la complexité est dans la séparation propre des frontières : la notification effective (KAN-56) reste différée, le gating acheteur (KAN-28) reste hors scope, le workflow statut (KAN-23) reste indépendant.
+
+## Packages touchés
+
+- [x] `packages/contracts` — `ProductCreateInput`, `ProductUpdateInput` : ajout de `low_stock_threshold` (nullable optional)
+- [x] `packages/core` — use cases `createProduct`, `updateProduct` : propager le champ ; pas de nouvelle erreur typée
+- [x] `packages/db` — vérifier que `productsRepo` mappe bien le champ en `create` / `update` (les types `Insert` / `Update` l'exposent déjà via `types.ts`)
+- [x] `apps/web` — `product-form.tsx` (activation du champ), `product-card.tsx` ou équivalent dans `components/producer/catalogue/`, `lib/products/stock-display.ts` (nouveau helper), `lib/products/adapters.ts` (vérification du mapping en écriture)
+- [ ] `apps/mobile` — hors scope
+- [ ] `packages/jobs` — pas d'event au MVP (KAN-56)
+- [ ] `supabase/migrations` — aucune migration (colonne déjà présente)
+- [ ] `supabase/policies` — aucun changement RLS (KAN-28 gérera le gating acheteur)
+- [ ] `packages/ui-web` — non promu (cohérent KAN-20/21)
+
+## Modèle de données
+
+Aucun changement. Pour mémoire, la colonne existe déjà :
+
+| Colonne | Type | Note |
+|---|---|---|
+| `low_stock_threshold` | `integer` | nullable, `CHECK low_stock_threshold IS NULL OR >= 0` (contrainte `products_low_stock_threshold_nonneg`). Commentaire SQL : « Seuil d'alerte stock (≥ 0, nullable). Câblé par KAN-22 (jobs notif `product.stock_low`). UI désactivée au MVP de KAN-20. » — à laisser tel quel, la mention « jobs notif » documente la cible KAN-56 sans engager KAN-22.
+
+Référence : `supabase/migrations/20260518000000_create_products.sql:104,177-180`, ARCHITECTURE.md §5, §18 entrée 1.22.
+
+## API / Endpoints
+
+Aucun nouvel endpoint. Les endpoints existants acceptent désormais `low_stock_threshold` :
+
+- `POST /api/v1/producer/products` — body étendu : `{ ..., low_stock_threshold?: number | null }`. Validation Zod : entier ≥ 0 ou `null`.
+- `PATCH /api/v1/producer/products/[id]` — idem, en optionnel partiel. `null` est accepté pour réinitialiser le seuil.
+
+Le `GET` (liste + détail) retourne déjà le champ via le snapshot (KAN-20).
+
+Pas de nouvelle erreur typée. Les bornes Zod (≥ 0) suffisent : un input invalide retourne `VALIDATION_ERROR` standard (cf. ARCHITECTURE.md §4.3).
+
+## Impact state machine / events
+
+Aucun. Pas de transition mission impactée. **Aucun event Inngest émis** : l'event `product.stock_low` cible KAN-56 (épic Notifications), pas KAN-22 — émettre sans consumer reviendrait à introduire du code mort.
+
+Pour mémoire, ARCHITECTURE.md §7.1 documente déjà `product.updated` comme déclencheur de recompute matching ; cet event reste différé à KAN-42 (matching) — non émis par KAN-22.
+
+## Dépendances
+
+Services externes : aucun nouveau. Référence : ARCHITECTURE.md §2. Pas de mise à jour `tech/setup.md`.
+
+Internes :
+- Table `products` (KAN-20) — colonne `low_stock_threshold` déjà créée.
+- Composant `<ProductForm />` (KAN-20) — extension du champ désactivé existant.
+- Composant `<ProductCard />` ou équivalent dans `apps/web/components/producer/catalogue/` (KAN-20) — câblage du badge stock.
+- `<ProductFormPreview />` (KAN-20) — câblage de l'état stock dans la card de preview.
+- `apps/web/lib/products/adapters.ts` (KAN-20) — vérification du mapping écriture.
+
+Aucune dépendance KAN-56 / KAN-54 / KAN-55 (différé).
+
+## État UI
+
+Référence : `DESIGN.md` (tokens, breakpoints), maquettes PR-05 (section 4) et PR-04 (CSS badges déjà posé : `.status-badge.epuise`, `.product-stock.low`, `.product-stock.empty`).
+
+**Formulaire PR-05 — Section 4 « Stock et disponibilité » :**
+- Champ « Seuil d'alerte stock » : retirer `disabled`, retirer l'overlay/libellé « (Bientôt — KAN-22) ». Conserver le helper text « Notification quand stock ≤ ce seuil. » (cohérent avec la maquette, et toujours vrai même si la notif effective arrive avec KAN-56 — l'écrit est neutre sur le canal).
+- Placeholder : `5` (cohérent avec la maquette).
+- Unité affichée à droite : dérivée du `packaging` choisi (cohérent avec le champ stock voisin, déjà câblé par KAN-20 via `unitShort`).
+- Type input : `number`, `min={0}`, `step={1}`, valeur vide = `null` à l'envoi.
+
+**Catalogue PR-04 — `<ProductCard />` :**
+- Badge en haut à gauche (`status-badge`) : si `stock === 0 && status === 'active'` → badge `epuise` (« Épuisé », CSS déjà posé). Sinon → badge correspondant au `status` (`actif` / `brouillon` / `desactive` — déjà câblé KAN-20).
+- Ligne stock sous le nom du produit :
+  - `stock === 0` → libellé barré « Épuisé » avec classe `product-stock.empty` (la maquette utilise « Inactif » pour un produit `disabled` ; on aligne sur « Épuisé » quand `status = 'active'` pour clarté).
+  - `stock > 0 && low_stock_threshold != null && stock <= low_stock_threshold` → « ⚠ N en stock » avec classe `product-stock.low`.
+  - sinon → « N en stock » (libellé neutre).
+- Pas de nouveau tab de filtre « Épuisés » dans la liste — le badge visuel suffit.
+
+**Preview PR-05 — `<ProductFormPreview />` :**
+- La card mockée vue acheteur reflète le badge stock (utiliser le même `<StockBadge />`).
+- Si `stock === 0` la note pédagogique « Ajoutez une photo… » est conservée ; un avertissement secondaire « Ce produit apparaîtra comme épuisé » est ajouté en orange sobre.
+
+**Composants à toucher dans `apps/web/components/producer/catalogue/` :**
+- `product-form.tsx` : activer le champ + ajouter au state local + au payload PATCH/POST.
+- `product-card.tsx` (ou nom équivalent) : consommer `getStockDisplayState`.
+- `product-form-preview.tsx` (ou équivalent) : idem.
+- Nouveau : `apps/web/lib/products/stock-display.ts` (helper pur, testable hors React).
+
+Mobile : non livré.
+
+## Risques techniques
+
+- **`null` côté input number** : le composant `<input type="number">` envoie une string vide quand l'utilisateur efface. Le state local doit normaliser `"" → null` avant l'envoi, et le payload PATCH doit transmettre `null` explicitement (pas `undefined`, sinon le champ n'est pas touché — pattern déjà utilisé sur `description` côté KAN-20). Test E2E pour couvrir : « renseigner un seuil, sauver, revenir, effacer, sauver → snapshot retourne `null` ».
+- **Re-render coût `getStockDisplayState`** : helper pur sans coût. Pas de mémorisation nécessaire.
+- **Cohérence du badge sur produit `draft` avec stock = 0** : décision retenue → ne pas afficher « Épuisé » pour un brouillon (le badge `brouillon` prime). Test unit explicite.
+- **Pas d'event Inngest = pas de notification au merge** : c'est volontaire et documenté en proposal. Risque côté produit : un utilisateur configure un seuil et s'attend à recevoir une alerte. Mitigation : l'écran PR-05 reste muet sur le canal (« Notification quand… ») — neutre. Si une mention produit explicite est nécessaire (« Les alertes arrivent prochainement »), à arbitrer en review.
+- **Affichage côté catalogue acheteur** : non touché. Un acheteur peut donc voir un produit `stock = 0` tant que `status = 'active'`. C'est la responsabilité de KAN-28 de gérer ce gating (ou pas). À documenter dans le commentaire du commit / PR pour ne pas surprendre.
+- **Compteurs de filtres** : la maquette PR-04 affiche des compteurs `(N)` sur chaque pill. Ces compteurs sont déjà câblés par KAN-20 sur `status`. KAN-22 ne touche pas — l'ajout éventuel d'un compteur « Épuisés » est out of scope.
+- **Test pre-existing** : `snapshot.test.ts:14` utilise `low_stock_threshold: null`. À vérifier que les fixtures de test des use cases / E2E couvrent aussi des valeurs non-null.
+
+## Tests envisagés
+
+Référence : ARCHITECTURE.md §10.
+
+- **Unit contracts (`packages/contracts/src/product/`)** :
+  - `create.test.ts` : `low_stock_threshold` accepté (null, 0, 5), refusé (-1, "5", float).
+  - `update.test.ts` : idem + cas `null` pour réinitialiser, `undefined` pour ne pas toucher.
+- **Unit core (`packages/core/src/product/`)** :
+  - `create-product.test.ts` : `low_stock_threshold` propagé dans le payload repo (null par défaut, valeur explicite).
+  - `update-product.test.ts` : `low_stock_threshold` propagé en PATCH (mise à jour, réinitialisation `null`, absence = pas de touche).
+- **Unit display (`apps/web/lib/products/stock-display.test.ts`)** :
+  - `stock = 0, status = 'active'` → `empty`.
+  - `stock = 0, status = 'draft'` → état neutre (le badge brouillon prime, le helper renvoie `empty` mais le composant `<ProductCard />` n'affiche pas le badge `epuise`).
+  - `stock = 3, threshold = 5` → `low`.
+  - `stock = 5, threshold = 5` → `low` (inclusif).
+  - `stock = 10, threshold = 5` → `ok`.
+  - `stock = 10, threshold = null` → `ok`.
+- **E2E web Playwright** (`apps/web/e2e/producer-catalogue.spec.ts`) — déféré si fixtures auth producteur non disponibles (cohérent KAN-20/21), sinon :
+  - Producteur édite un produit, renseigne `low_stock_threshold = 5`, sauve, recharge → seuil persisté.
+  - Producteur passe `stock` à 0, sauve → la card du catalogue affiche badge « Épuisé ».
+  - Producteur efface le seuil, sauve → snapshot retourne `null`, badge « stock bas » disparaît.

--- a/specs/KAN-22/proposal.md
+++ b/specs/KAN-22/proposal.md
@@ -1,0 +1,56 @@
+# Cadrage — KAN-22 Stock & alertes
+
+## Liens
+
+- Jira : https://erkulaws.atlassian.net/browse/KAN-22
+- Epic : KAN-5 Catalogue
+- Maquettes :
+  - `design/maquettes/producteur/pr-05-edition-produit.html` (section 4 « Stock et disponibilité » — champ « Seuil d'alerte stock » actuellement désactivé par KAN-20)
+  - `design/maquettes/producteur/pr-04-catalogue.html` (badges `.status-badge.epuise`, `.product-stock.low`, `.product-stock.empty` — CSS déjà posé)
+- PRD : §10.2 PR-05 Création / édition produit, §10.2 PR-04 Catalogue produits
+- ARCHITECTURE : §5 (DB — colonne `low_stock_threshold` déjà présente), §7.1 (event `product.updated` — toujours hors scope), §14 (playbook), §18 entrée 1.22 (table `products` posée par KAN-20)
+
+## Pourquoi (côté tech)
+
+KAN-20 a livré la table `products` avec la colonne `low_stock_threshold integer` nullable, la CHECK `products_low_stock_threshold_nonneg`, et un champ « Seuil d'alerte stock » désactivé dans le formulaire PR-05 (overlay « Bientôt — KAN-22 »). Le snapshot de produit expose déjà la valeur (`packages/contracts/src/product/snapshot.ts:36`), mais aucun des schémas d'input (`ProductCreateInput`, `ProductUpdateInput`) ni des use cases (`createProduct`, `updateProduct`) ne la propage. Aucune logique d'affichage de stock dérivé (« Épuisé », « stock bas ») n'est câblée.
+
+KAN-22 active réellement la couche stock du catalogue producteur : (a) persistance du seuil d'alerte (subtask KAN-74), (b) affichage automatique de l'état « Épuisé » en UI quand le stock atteint zéro (subtask KAN-75), (c) affichage de l'état « stock bas » quand `stock ≤ low_stock_threshold`. Aucune migration DB n'est nécessaire — tout est déjà préparé. La **delivery effective des notifications** (email / in-app / push quand le seuil est franchi) reste portée par KAN-56 (épic Notifications) ; KAN-22 ne câble pas d'event Inngest tant que son consommateur n'existe pas.
+
+## Périmètre technique
+
+**In scope :**
+
+- Étendre `ProductCreateInput` et `ProductUpdateInput` (`packages/contracts/src/product/create.ts`, `update.ts`) avec `low_stock_threshold: z.number().int().min(0).nullable().optional()`. Tests Zod associés (`create.test.ts`, `update.test.ts`).
+- Propager le champ dans les use cases `createProduct` et `updateProduct` (`packages/core/src/product/`) + tests unitaires.
+- Propager dans le repo `productsRepo` (`packages/db/src/products/`) — `Insert` et `Update` types incluent déjà `low_stock_threshold` (cf. `packages/db/src/types.ts:281,301,316`), à vérifier que les mapping helpers le passent.
+- Propager dans l'adapter web (`apps/web/lib/products/adapters.ts`) — déjà mappé en lecture, à vérifier en écriture.
+- Activer le champ « Seuil d'alerte stock » dans `apps/web/components/producer/catalogue/product-form.tsx` (retirer `disabled`, l'overlay « Bientôt — KAN-22 », câbler l'état local `lowStockThreshold` et l'inclure dans le PATCH/POST).
+- Helper UI `getStockDisplayState(product) → { kind: 'ok' | 'low' | 'empty', label: string }` dans `apps/web/lib/products/stock-display.ts`. Logique pure :
+  - `stock === 0 && status === 'active'` → `empty` (badge « Épuisé » + libellé barré « Inactif »)
+  - `stock > 0 && low_stock_threshold != null && stock <= low_stock_threshold` → `low` (libellé « ⚠ N en stock » orange)
+  - sinon → `ok` (libellé « N en stock »)
+- Câblage du helper dans `<ProductCard />` (catalogue PR-04) : remplacer le libellé statique par `<StockBadge state={…} />`, idem pour le badge de statut (afficher `epuise` au lieu de `actif` quand `stock === 0`).
+- Câblage du helper dans `<ProductFormPreview />` (panneau droit de PR-05) : refléter l'état stock dans la card de prévisualisation.
+- Tests unit du helper `getStockDisplayState` (5 scénarios : ok, low, empty-active, empty-draft, threshold-null).
+- Si la liste PR-04 expose un compteur statut (badge filtres) : ajouter le décompte « Épuisés » dérivé côté liste (côté serveur via `WHERE stock = 0 AND status = 'active'`, optionnel — voir Hypothèses).
+
+**Out of scope (cette US) :**
+
+- **Notification delivery (event `product.stock_low`)** : émission + consumer (email Resend / in-app KAN-55 / push KAN-54) sont portés par KAN-56 « Alertes stock producteur » sous l'épic Notifications. Émettre un event sans consumer reviendrait à introduire du code mort — décision : on attend KAN-56. La donnée nécessaire (snapshot pré-update / post-update du stock + seuil) sera disponible côté use case `updateProduct` quand KAN-56 arrivera, sans changement structurel.
+- **Nouvelle valeur enum `product_status = 'sold_out'`** : refusé. « Épuisé » est un état **dérivé** à l'affichage (fonction de `stock` + `status`), pas un statut applicatif persisté. Cohérent avec le pattern « status enum = visibilité applicative » documenté par KAN-20 (commentaire SQL ligne 89 de la migration). Évite la complexité d'un mini-state-machine produit (`active ↔ sold_out` au gré des updates de stock) et la divergence DB / réalité (un producteur qui ré-approvisionne `stock = 24` veut que le badge « Actif » revienne automatiquement).
+- **Gating catalogue acheteur sur stock = 0** : la RLS `products_select_public` filtre actuellement sur `status = 'active'` mais pas sur `stock > 0`. KAN-22 ne touche pas à cette RLS — la question « un produit épuisé est-il visible à l'acheteur » relève de KAN-28 (catalogue acheteur) qui définira la stratégie (masquage, badge épuisé, ajout possible en wishlist, etc.).
+- **Workflow draft → active dépendant du stock** : aucun pré-requis ajouté (KAN-23 gère).
+- **Décrémentation automatique du stock lors d'une réservation** : modélisée par KAN-31 (Notification & confirmation match) + KAN-34 (Escrow). KAN-22 ne touche pas le stock côté flow de commande.
+- **Migration DB** : aucune. La colonne, la CHECK et le commentaire existent déjà.
+- **Mobile** : non livré (cohérent avec l'épic KAN-5).
+
+## Hypothèses
+
+- La valeur `low_stock_threshold = 0` est techniquement valide (CHECK `>= 0`) mais sans intérêt métier (alerte permanente). Le placeholder UI suggère « ex : 5 » et le helper text « Notification quand stock ≤ ce seuil » reste tel quel — pas de validation Zod supplémentaire pour interdire 0.
+- `low_stock_threshold = null` (cas par défaut) signifie « pas d'alerte » : aucun badge « stock bas » affiché, quel que soit le stock. Cohérent avec la maquette PR-04 où la card sans seuil affiche « 18 en stock » sans warning.
+- L'état « Épuisé » s'applique uniquement quand `status = 'active'`. Pour `status = 'draft'` ou `'disabled'`, le stock n'a pas d'effet visuel — le badge de statut existant prime (« Brouillon », « Désactivé »). C'est cohérent avec la maquette PR-04 (la card « Désactivée » montre `stock empty` barré « Inactif » sans badge « Épuisé » distinct).
+- Le compteur de filtres « Tous (N) / Actifs (N) / Brouillons (N) / Désactivés (N) » de la maquette PR-04 ne distingue pas « Actifs » et « Épuisés » dans les tabs : un produit `status = active, stock = 0` reste comptabilisé dans « Actifs ». Le badge `epuise` est purement visuel sur la card. Pas de nouveau tab « Épuisés ».
+- La règle « Stock ≤ seuil » est strictement inclusive : `stock = threshold` déclenche le badge « stock bas ». Cohérent avec le helper text de la maquette PR-05 (« Notification quand stock ≤ ce seuil »).
+- Le champ « Seuil d'alerte stock » accepte une valeur **vide** (= `null` persisté). Si l'utilisateur entre une valeur puis efface, le PATCH transmet `null` explicitement (cohérent avec le pattern `description: null` côté `ProductUpdateInput`).
+- Pas d'événement Inngest émis. Le jour où KAN-56 arrive, le hook se posera dans `updateProduct` (use case core) — la signature actuelle expose déjà `previousStock` côté repo si besoin, ou un re-fetch léger suffira. Pas de provision structurelle nécessaire au MVP de KAN-22.
+- Les composants UI restent dans `apps/web/components/producer/catalogue/` (pas de promotion vers `packages/ui-web/`) — cohérent KAN-20/21, pas de réutilisation cross-app prévue.

--- a/specs/KAN-22/tasks.md
+++ b/specs/KAN-22/tasks.md
@@ -1,0 +1,32 @@
+# Tâches techniques internes — KAN-22 Stock & alertes
+
+> Ces tâches ne sont pas dans Jira. Setup, migrations, refacto, helpers partagés, seeds, configuration — tout ce qui n'a pas vocation à être tracké comme livrable produit.
+>
+> Subtasks Jira existantes (rappel — ne pas dupliquer ici) :
+> - KAN-74 : Renseigner le stock disponible et définir un seuil d'alerte
+> - KAN-75 : Affichage automatique du statut « Épuisé » quand le stock atteint zéro
+
+## Tâches
+
+- [ ] Étendre `ProductCreateInput` (`packages/contracts/src/product/create.ts`) avec `low_stock_threshold: z.number().int().min(0).nullable().optional()`.
+- [ ] Étendre `ProductUpdateInput` (`packages/contracts/src/product/update.ts`) idem.
+- [ ] Ajouter cas de test `low_stock_threshold` dans `packages/contracts/src/product/create.test.ts` et `update.test.ts` (null, 0, 5, négatif refusé, float refusé).
+- [ ] Propager `low_stock_threshold` dans `createProduct` et `updateProduct` (`packages/core/src/product/`) + tests unit (couvrir null par défaut, valeur explicite, réinitialisation via PATCH).
+- [ ] Vérifier que `productsRepo` (`packages/db/src/products/`) mappe bien `low_stock_threshold` en `create` et `update` (types déjà exposés via `packages/db/src/types.ts:281,301,316` — purement vérification, à corriger si manquant).
+- [ ] Vérifier que l'adapter web (`apps/web/lib/products/adapters.ts`) propage le champ dans les deux sens (lecture déjà câblée KAN-20 ligne 28 ; écriture à confirmer).
+- [ ] Créer `apps/web/lib/products/stock-display.ts` : helper pur `getStockDisplayState(product) → { kind: 'ok' | 'low' | 'empty' }` + types exportés.
+- [ ] Créer `apps/web/lib/products/stock-display.test.ts` : 5+ scénarios (ok, low avec stock = threshold, low avec stock < threshold, empty + active, empty + draft, threshold null).
+- [ ] Modifier `apps/web/components/producer/catalogue/product-form.tsx` :
+  - Retirer `disabled`, `readOnly`, la classe `opacity-50` et le libellé « (Bientôt — KAN-22) » du champ « Seuil d'alerte stock ».
+  - Ajouter `lowStockThreshold` au state local + reset, et inclure dans le payload PATCH/POST (avec normalisation `"" → null`).
+  - Mettre à jour le commentaire en tête (« 4. Stock et fenêtre de disponibilité (low_stock_threshold désactivé) » → version sans cette mention).
+- [ ] Modifier le composant card de catalogue (`apps/web/components/producer/catalogue/product-card.tsx` ou nom équivalent) : consommer `getStockDisplayState`, basculer le badge `status-badge` vers `epuise` quand le helper renvoie `empty` + `status === 'active'`, basculer la ligne `product-stock` vers `low` / `empty` selon le `kind`.
+- [ ] Modifier `<ProductFormPreview />` (composant preview de PR-05) : afficher le badge stock dérivé et une note secondaire orange « Ce produit apparaîtra comme épuisé » quand `stock === 0 && status === 'active'`.
+- [ ] Vérifier que les fixtures de test repo / core qui créent un produit acceptent `low_stock_threshold` (ajustement minimal des `test-helpers.ts` si besoin — ligne 19 référence déjà `low_stock_threshold: null`).
+- [ ] (Optionnel) Mettre à jour le snapshot du commentaire SQL `COMMENT ON COLUMN public.products.low_stock_threshold` si la mention « UI désactivée au MVP de KAN-20 » devient trompeuse. Décision : laisser tel quel pour éviter une migration de doc — la mention historique est inoffensive et le commentaire reste juste sur la cible KAN-56 (notif delivery).
+- [ ] Mettre à jour `produit/jira_mapping.md` : ligne de KAN-22 dans la table « Catalogue Jira complet » + cellule « Tickets liés » du PR-05 dans le parcours Producteur — ajouter mention `[Cadrage tech](specs/KAN-22/)` ; ajuster la ligne « État au YYYY-MM-DD » si nécessaire.
+- [ ] Mettre à jour `ARCHITECTURE.md` §18 (journal) avec une entrée datée résumant la livraison KAN-22 (au moment du merge implémentation, pas du cadrage).
+
+## Checklist pre-merge
+
+Voir ARCHITECTURE.md §14.3 — ne pas dupliquer ici.


### PR DESCRIPTION
Cadrage technique de la feature Jira [KAN-22 « Stock & alertes »](https://erkulaws.atlassian.net/browse/KAN-22) (épic KAN-5 Catalogue).

## Périmètre

Trois specs courtes dans `specs/KAN-22/` :

- `proposal.md` — pourquoi, in/out scope, hypothèses.
- `design.md` — packages touchés, modèle de données (rappel — aucune migration), API, UI, risques, tests.
- `tasks.md` — tâches techniques internes (validation Zod, propagation use cases + repo + adapter, helper `getStockDisplayState`, câblage form + card + preview, tests).

## Choix structurants

- **Aucune migration DB** : la colonne `low_stock_threshold` et la CHECK sont déjà posées par KAN-20.
- **« Épuisé » = état dérivé à l'affichage** (`stock = 0 && status = 'active'`), pas une valeur enum `product_status = 'sold_out'`. Évite la complexité d'une mini-state-machine produit et la divergence DB / réalité lors d'un ré-approvisionnement.
- **Pas d'event Inngest `product.stock_low`** au MVP de KAN-22 : la notification effective (email/push/in-app) est portée par KAN-56 « Alertes stock producteur » sous l'épic Notifications. Émettre sans consumer = code mort.
- **Pas de gating catalogue acheteur** sur `stock = 0` : KAN-22 ne touche pas la RLS `products_select_public` — cette décision relève de KAN-28 (catalogue acheteur).

## Synchronisations

- `produit/jira_mapping.md` : ligne KAN-22 (catalogue épic KAN-5) + cellule « Tickets liés » du PR-05 (parcours Producteur) — mention `[Cadrage tech](specs/KAN-22/)` ajoutée.
- Jira KAN-22 : commentaire + section « Cadrage technique » dans la description (liens uniquement, source de vérité = repo).
- Transition `Ideas → À faire` déclenchée au merge de cette PR (cf. CLAUDE.md « Après merge d'une PR KAN-XXX sur `main` »).

## Test plan

- [ ] CI verte (lint, type-check, tests existants — pas de code applicatif modifié).
- [ ] Validation produit asynchrone — relire le brouillon, ouvrir le débat sur le gating acheteur si besoin.

Au merge : transition Jira `Ideas → À faire`, MAJ mapping, désabonnement de cette PR, puis enchaînement automatique sur `/implement KAN-22`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cnms2r9Yrz8tKXSPpqsjWr)_