### PR TITLE
specs KAN-23 — Statuts produit (cadrage)

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -9,7 +9,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 - **13 épics** (KAN-1, KAN-4 → KAN-15) — un épic par grand domaine fonctionnel
 - **50 features cataloguées** (KAN-2, KAN-3 sous KAN-1 ; KAN-16 → KAN-158 sous les autres épics — voir tables par épic ci-dessous)
 - **Subtasks** : voir le catalogue par épic ci-dessous. Le mapping peut être incomplet pour les subtasks les plus récentes — Jira fait foi pour la liste exhaustive.
-- État au 2026-05-18 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-17 *Terminé* (mergé sur `main` — PR #18, cadrage `specs/KAN-17/`) ; KAN-18 *Terminé* (mergé sur `main` — PR #21, cadrage `specs/KAN-18/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; KAN-19 *Examiner* (mergé sur `main` — PR #25, cadrage `specs/KAN-19/`) ; KAN-20 *Examiner* (mergé sur `main` — PR #30, cadrage `specs/KAN-20/`) ; KAN-21 *Examiner* (mergé sur `main` — PR #34, cadrage `specs/KAN-21/`) ; KAN-22 *Examiner* (mergé sur `main` — PR #38, cadrage `specs/KAN-22/`) ; autres *Ideas*
+- État au 2026-05-18 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-17 *Terminé* (mergé sur `main` — PR #18, cadrage `specs/KAN-17/`) ; KAN-18 *Terminé* (mergé sur `main` — PR #21, cadrage `specs/KAN-18/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; KAN-19 *Examiner* (mergé sur `main` — PR #25, cadrage `specs/KAN-19/`) ; KAN-20 *Examiner* (mergé sur `main` — PR #30, cadrage `specs/KAN-20/`) ; KAN-21 *Examiner* (mergé sur `main` — PR #34, cadrage `specs/KAN-21/`) ; KAN-22 *Examiner* (mergé sur `main` — PR #38, cadrage `specs/KAN-22/`) ; KAN-23 *Ideas* (cadrage en cours, `specs/KAN-23/`) ; autres *Ideas*
 - **Maquettes (2026-05-14)** : les 35 écrans des 3 parcours (Producteur, Acheteur, Rameneur) du sitemap PRD §10 sont maquettés. Restent à maquetter : transverses **TR-02** (centre notifications) et **TR-04** (signalement / litige) ; **TR-03** est couvert par `rm-09-chat.html`. Index navigable de toutes les maquettes : `design/maquettes/index.html`
 
 ## Convention de référencement
@@ -30,7 +30,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | PR-01 Inscription / connexion | `pr-01-authentication.html` | KAN-2 (Création de compte), KAN-3 (Connexion), KAN-157 (Récup. mot de passe) | [Cadrage KAN-2](specs/KAN-2/), [Cadrage KAN-3](specs/KAN-3/), [Cadrage KAN-157](specs/KAN-157/) |
 | PR-02 Onboarding Stripe Connect | `pr-02-onboarding-stripe.html` | KAN-16 (Onboarding Stripe Connect) — [Cadrage tech](specs/KAN-16/) | KAN-62, KAN-158 (polish UX restricted) |
 | PR-03 Dashboard | `pr-03-dashboard.html` | KAN-18 (Tableau de bord producteur) — [Cadrage tech](specs/KAN-18/) | KAN-56 |
-| PR-04 Catalogue produits | `pr-04-catalogue.html` | KAN-20 (Création & édition produit) — [Cadrage tech](specs/KAN-20/) | KAN-23 (Statuts produit) |
+| PR-04 Catalogue produits | `pr-04-catalogue.html` | KAN-20 (Création & édition produit) — [Cadrage tech](specs/KAN-20/) | KAN-23 (Statuts produit) — [Cadrage tech](specs/KAN-23/) |
 | PR-05 Création / édition produit | `pr-05-edition-produit.html` | KAN-20 (Création & édition produit) — [Cadrage tech](specs/KAN-20/) | KAN-21 (Photos) — [Cadrage tech](specs/KAN-21/), KAN-22 (Stock) — [Cadrage tech](specs/KAN-22/), KAN-24 (Labels & catégories) |
 | PR-06 Récupération à venir | `pr-06-recuperation.html` | KAN-46 (QR Pickup), KAN-47 (Checklist remise producteur) | KAN-45 |
 | PR-07 Historique ventes | `pr-07-historique-ventes.html` | KAN-19 (Historique ventes) — [Cadrage tech](specs/KAN-19/) | KAN-36 (Factures PDF) |
@@ -120,7 +120,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | KAN-20 | Feature | Examiner | Création & édition produit — [Cadrage tech](specs/KAN-20/) — mergé sur main (PR #30) |
 | KAN-21 | Feature | Examiner | Gestion photos — [Cadrage tech](specs/KAN-21/) — mergé sur main (PR #34) |
 | KAN-22 | Feature | Examiner | Stock & alertes — [Cadrage tech](specs/KAN-22/) — mergé sur main (PR #38) |
-| KAN-23 | Feature | Ideas | Statuts produit |
+| KAN-23 | Feature | Ideas | Statuts produit — [Cadrage tech](specs/KAN-23/) |
 | KAN-24 | Feature | Ideas | Labels & catégories |
 
 ### KAN-6 — Profil Acheteur

--- a/specs/KAN-23/design.md
+++ b/specs/KAN-23/design.md
@@ -1,0 +1,153 @@
+# Conception technique — KAN-23 Statuts produit
+
+## Vue d'ensemble
+
+Mouvement principal : ajouter un mini-graphe de transitions au-dessus de la table `products` existante, sans migration. Toute la logique est applicative et tient dans (a) un use case `transitionProductStatus` qui valide la transition + applique les préconditions de publication, (b) un endpoint d'action dédié `POST /…/status`, (c) du câblage UI sur deux composants déjà livrés (`<CatalogueFilters />` et `<ProductCard />` pour le tab « Épuisés » et le menu kebab) et un nouveau bloc inline dans `<ProductForm />`.
+
+Pas de state machine formelle (pas de discriminated union à la Mission §6 ARCHITECTURE) : trois statuts, six transitions, c'est sous le seuil où une `switch` lisible coûte moins qu'une abstraction. Pas d'event Inngest, pas d'`audit_trail` — la traçabilité des transitions est différée.
+
+## Packages touchés
+
+Référence : ARCHITECTURE.md §14.2.
+
+- [x] `packages/contracts` — nouveau `productTransitionStatusInput` (Zod), extension de `productListQuerySchema` (status accepte `'sold_out'`), erreurs typées exposées
+- [x] `packages/core` — nouveau use case `transition-product-status.ts` + erreurs `PRODUCT_TRANSITION_*`, helper pur `getPublishPreconditions(product)` (réutilisé UI + use case)
+- [x] `packages/db` — pas de schema neuf ; `productsRepo.findByOwner` étendu pour accepter le filtre `sold_out` et retourner les `counts` (5 valeurs)
+- [x] `apps/web` — adapter web (`apps/web/lib/products/adapter.ts`) : nouvelle méthode `transitionStatus`, route handler `app/api/v1/producer/products/[id]/status/route.ts`, composants `<CatalogueFilters />`, `<ProductCard />`, `<ProductForm />`
+- [ ] `apps/mobile` — hors scope
+- [ ] `packages/jobs` — aucun event au MVP (différé KAN-56)
+- [ ] `supabase/migrations` — aucune migration
+- [ ] `supabase/policies` — pas de changement RLS (le filtre `sold_out` est appliqué côté repo, RLS owner `auth.uid() = producer_user_id` couvre déjà tout)
+- [ ] `packages/ui-web` — non promu (cohérent KAN-20/21/22)
+
+## Modèle de données
+
+Aucun changement DB. Pour mémoire :
+
+| Colonne | Type | Note |
+|---|---|---|
+| `status` | `product_status not null default 'active'` | enum `'active' \| 'draft' \| 'disabled'`. CHECK existant (KAN-20). |
+
+Le statut dérivé `sold_out` n'est **pas** persisté — calculé à la lecture (`status = 'active' AND stock = 0`). Cohérent avec la décision documentée dans `specs/KAN-22/proposal.md` (« Nouvelle valeur enum `product_status = 'sold_out'` : refusé »).
+
+Référence : `supabase/migrations/20260518000000_create_products.sql`, ARCHITECTURE.md §5, §18 entrée 1.22.
+
+## API / Endpoints
+
+Référence : ARCHITECTURE.md §3, §4.3, §14.2.
+
+- **Nouveau** : `POST /api/v1/producer/products/[id]/status`
+  - Body Zod : `{ status: 'active' | 'draft' | 'disabled' }`.
+  - Use case : `transitionProductStatus(productId, targetStatus, ownerUserId)`.
+  - Réponses : `200 OK` avec snapshot du produit ; `400 PRODUCT_TRANSITION_INVALID` (transition non autorisée) ; `400 PRODUCT_PUBLISH_MISSING_*` (préconditions) ; `404 PRODUCT_NOT_FOUND` ; `403 PRODUCT_FORBIDDEN`.
+- **Étendu** : `GET /api/v1/producer/products`
+  - Query Zod : `status: z.enum(['all','active','draft','disabled','sold_out']).optional()` (au lieu de `'all' | 'active' | 'draft' | 'disabled'` côté KAN-20).
+  - Response : ajout d'un objet `counts: { all, active, draft, disabled, sold_out }` à côté de `{ items, nextCursor }`. Toujours retourné (même en mode filtré, pour stabiliser les badges des tabs).
+- **Inchangés** : `POST`, `GET /[id]`, `PATCH /[id]`, `DELETE /[id]`. Le `PATCH` accepte toujours `status` ; si `status` est présent et différent de l'actuel, le handler **délègue** au use case `transitionProductStatus` plutôt que d'appliquer un update naïf. Évite la divergence des chemins (cf. proposal § Hypothèses).
+
+Erreurs typées (nouvelles) :
+
+- `PRODUCT_TRANSITION_INVALID` — la transition n'est pas dans le graphe (ex : appelée vers le statut courant, ou statut inconnu).
+- `PRODUCT_PUBLISH_MISSING_NAME` — non null mais vide après trim (sécurité ; en pratique bloqué par le CHECK DB sur `length ≥ 1`).
+- `PRODUCT_PUBLISH_MISSING_DESCRIPTION` — null ou vide après trim.
+- `PRODUCT_PUBLISH_MISSING_PRICE` — `unit_price_cents <= 0` (sécurité ; bloqué par CHECK DB).
+- `PRODUCT_PUBLISH_MISSING_STOCK` — `stock <= 0`.
+- `PRODUCT_PUBLISH_MISSING_PHOTOS` — `photos` vide.
+- `PRODUCT_PUBLISH_AVAILABILITY_EXPIRED` — `availability_to < current_date`.
+
+Chaque erreur expose un `details` listant la précondition manquante pour permettre à l'UI d'afficher un message ciblé.
+
+## Impact state machine / events
+
+Aucun. Pas de transition mission impactée, aucun event Inngest émis (cohérent KAN-22 — pas de consumer en place). La table `mission_events` (ARCHITECTURE §6) n'est pas touchée — pas d'équivalent `product_events` créé au MVP.
+
+## Dépendances
+
+Services externes : aucun. Référence : ARCHITECTURE.md §2. Pas de mise à jour `tech/setup.md`.
+
+Internes :
+
+- Table `products` (KAN-20) — colonnes `status`, `stock`, `photos`, `description`, `availability_to` lues pour les préconditions.
+- Use case `updateProduct` (KAN-20) — pattern repris pour la signature du nouveau use case (auth via `ownerUserId`, fetch + update, erreur typée si non trouvé).
+- Helper `getStockDisplayState` (KAN-22, dans `packages/core/src/product/stock-display.ts`) — non touché, la dérivation `sold_out` reste pure côté affichage. Le filtrage `sold_out` côté liste est implémenté **séparément** dans le repo (clause `WHERE status = 'active' AND stock = 0`) pour cohérence DB.
+- Composant `<CatalogueFilters />` (KAN-20) — étendu avec un 5ᵉ tab.
+- Composant `<ProductCard />` (KAN-20/22) — menu kebab câblé.
+- Composant `<ProductForm />` (KAN-20/22) — section 5 enrichie de messages inline.
+
+## État UI
+
+Référence : DESIGN.md (tokens, breakpoints) ; maquettes PR-04 et PR-05.
+
+**Catalogue PR-04 — `<CatalogueFilters />` :**
+
+- 5 tabs : `Tous (N) / Actifs (N) / Brouillons (N) / Désactivés (N) / Épuisés (N)`.
+- Le tab actif applique `?status=<value>` à la query de liste.
+- Compteurs récupérés depuis `response.counts` (re-fetch après transition).
+- Style : tab « Épuisés » réutilise la couleur orange `--orange-500` du badge `epuise` pour l'indicateur actif (cohérent visuel avec la card). Le CSS du tab `filter-pill.active` reste vert ; le tab Épuisés actif passe en orange (`background: var(--orange-500)`). À valider visuellement en review.
+
+**Catalogue PR-04 — `<ProductCard />` :**
+
+- Menu kebab `product-menu-btn` : `onClick` ouvre un `<DropdownMenu />` (réutilisable shadcn). Actions selon le statut courant :
+  - `active` → « Mettre en brouillon » + « Désactiver » + (séparateur) « Supprimer »
+  - `draft` → « Publier » (= transition vers `active`) + « Désactiver » + (séparateur) « Supprimer »
+  - `disabled` → « Réactiver » (= transition vers `active`) + « Mettre en brouillon » + (séparateur) « Supprimer »
+- Chaque clic → `POST .../status` → `toast.success("Produit publié")` ou `toast.error(...)`. En cas d'erreur de précondition, le toast inclut un lien « Compléter la fiche » qui pointe sur `/producer/catalogue/[id]` avec query `?focus=publish` (le formulaire scrolle sur la section 5 et affiche la liste des préconditions manquantes en rouge).
+- Badge `epuise` (KAN-22) reste affiché tel quel quand `stock = 0 && status = 'active'`.
+
+**Formulaire PR-05 — `<ProductForm />`, section 5 « Visibilité » :**
+
+- Sous le radio `Actif`, un bloc compact « Pour publier, il faut » qui liste dynamiquement les préconditions manquantes (basées sur le helper `getPublishPreconditions(product)`). Coché ✓ vert = OK, ◯ gris = manquant.
+- Le bouton « Enregistrer » reste **toujours actif** : si l'utilisateur soumet `status = 'active'` avec préconditions manquantes, le serveur renvoie l'erreur typée → toast d'erreur ciblé + scroll sur la section 5 + highlight des préconditions manquantes.
+- Si `?focus=publish` est dans l'URL au chargement, scroll initial sur la section 5 et tooltip ouvert.
+
+**Préconditions affichées (libellés FR) :**
+
+- « Un nom » ✓ (toujours présent — sécurité)
+- « Une description » (requis non vide)
+- « Un prix > 0 € »
+- « Au moins 1 article en stock »
+- « Au moins 1 photo »
+- « Une fenêtre de disponibilité valide » (si `availability_to` est dans le passé)
+
+**Composants nouveaux / modifiés dans `apps/web/components/producer/catalogue/` :**
+
+- `catalogue-filters.tsx` — ajout du tab « Épuisés », couleur orange pour actif.
+- `product-card.tsx` — ajout du `<DropdownMenu />` câblé, handlers de transition.
+- `product-form.tsx` — section 5 enrichie ; ajout du bloc « Pour publier, il faut » dynamique.
+- Nouveau composant `<PublishPreconditionsList />` (interne à `product-form.tsx` ou fichier dédié) qui mappe le retour de `getPublishPreconditions` à la liste cochée.
+
+Mobile : non livré.
+
+## Risques techniques
+
+- **`PATCH /[id]` qui contient `status` + autres champs** : si l'utilisateur édite description ET passe en `active` dans la même soumission, le handler doit appliquer d'abord les autres champs (`updateProduct`), puis tenter la transition (`transitionProductStatus`). Sinon les préconditions se déclencheront sur l'état **pré-update**. Ordre à formaliser dans le handler `PATCH` (cf. tasks.md). Test E2E ciblé à écrire.
+- **Concurrence transition / update** : un producteur clique « Désactiver » dans le menu kebab pendant que la liste se re-fetch après une autre action. Pas de verrou pessimiste — l'`updated_at` du snapshot permet une vérification optimiste si nécessaire, mais on accepte le « last write wins » au MVP.
+- **Décompte `sold_out`** : la requête SQL `COUNT(*) FILTER (WHERE status = 'active' AND stock = 0)` se calcule sans nouveau index (l'index `(producer_user_id, status) WHERE deleted_at IS NULL` posé par KAN-20 couvre déjà le scan). À surveiller si un producteur a > 1000 produits — peu probable au MVP.
+- **Erreurs typées en cascade** : si plusieurs préconditions sont manquantes, le use case doit toutes les retourner d'un coup (`PRODUCT_TRANSITION_INVALID` avec `details.missing: ['photos', 'stock']`) plutôt qu'au compte-gouttes. Sinon l'UI doit faire N allers-retours pour voir tous les manques. Convention de retour à formaliser.
+- **Tab Épuisés en orange** : si la couleur jure dans la grille des tabs (vert / vert / vert / vert / orange), tomber sur un style plus neutre (border orange + texte orange, mais background blanc). À tester visuellement.
+- **`focus=publish` côté URL** : nouvelle convention, à documenter en commentaire de tête du `<ProductForm />`. Pas de risque d'XSS (query param consommée via `useSearchParams` Next, jamais injectée dans le DOM).
+- **Conformité avec décision KAN-22 (« pas de tab Épuisés »)** : KAN-23 contredit. Justifié par le subtask KAN-77. À mentionner explicitement dans le commit + journal §18 d'ARCHITECTURE.md.
+
+## Tests envisagés
+
+Référence : ARCHITECTURE.md §10.
+
+- **Unit contracts (`packages/contracts/src/product/`)** :
+  - `transition-status.test.ts` : Zod accepte `'active' | 'draft' | 'disabled'`, refuse `'sold_out'` (statut dérivé, non transitionable).
+  - `list.test.ts` (étendu) : `status` accepte `'sold_out'` ; refuse les valeurs inconnues.
+- **Unit core (`packages/core/src/product/`)** :
+  - `transition-product-status.test.ts` :
+    - Transitions valides : `draft → active` avec préconditions OK ; `active → draft` ; `active → disabled` ; `disabled → active` ; `draft → disabled` ; `disabled → draft`.
+    - Transitions refusées : `active → active` (no-op refusé `PRODUCT_TRANSITION_INVALID`), statut inconnu.
+    - Préconditions : chaque manque retourne sa propre erreur typée. Multi-manques retournent une seule erreur agrégée `PRODUCT_TRANSITION_INVALID` avec `details.missing`.
+    - Sécurité : tentative de transition sur un produit d'un autre owner → `PRODUCT_FORBIDDEN`.
+  - `get-publish-preconditions.test.ts` (helper pur) : tous les combinaisons (5 préconditions × OK/KO).
+  - `list-owner-products.test.ts` (étendu) : filtre `sold_out` retourne uniquement les produits `active, stock = 0` ; `counts` retournés cohérents.
+- **Unit display** : `stock-display.test.ts` (KAN-22) inchangé. Pas de nouveau helper d'affichage.
+- **E2E web Playwright** (`apps/web/e2e/producer-catalogue.spec.ts`, étendu) :
+  - Producteur crée un produit minimal (sans photo) en `draft`, tente de publier via le menu kebab → toast d'erreur + lien « Compléter la fiche » qui ouvre le formulaire avec la section 5 en focus.
+  - Producteur ajoute une photo + stock + description, publie via le formulaire → produit `active` apparaît dans le tab « Actifs ».
+  - Producteur passe `stock` à 0 (toujours `active`), la liste affiche le badge « Épuisé » et le tab « Épuisés (1) » apparaît avec le décompte correct.
+  - Quick action « Désactiver » depuis la card d'un produit `active` → bascule en `disabled` sans confirmation, toast succès, tab « Désactivés (1) » à jour.
+  - Filtres : naviguer entre les 5 tabs, vérifier que les `items` correspondent à la query.
+- **Tests RLS DB** : différés (cohérent KAN-20/21/22) — pas de changement RLS dans KAN-23 de toute façon.

--- a/specs/KAN-23/proposal.md
+++ b/specs/KAN-23/proposal.md
@@ -1,0 +1,58 @@
+# Cadrage — KAN-23 Statuts produit
+
+## Liens
+
+- Jira : https://erkulaws.atlassian.net/browse/KAN-23
+- Epic : KAN-5 Catalogue
+- Maquettes :
+  - `design/maquettes/producteur/pr-04-catalogue.html` (tabs filtres `Tous / Actifs / Brouillons / Désactivés`, badges `actif / brouillon / epuise / desactive`, menu kebab `product-menu-btn`)
+  - `design/maquettes/producteur/pr-05-edition-produit.html` (section 5 « Visibilité » — tri-état radios)
+- PRD : §10.2 PR-04 Catalogue produits, §10.2 PR-05 Création / édition produit
+- ARCHITECTURE : §3 (monorepo), §4.3 (erreurs typées), §10 (tests), §14 (playbook), §18 entrée 1.22 (table `products` posée par KAN-20)
+
+## Pourquoi (côté tech)
+
+KAN-20 a posé l'enum `product_status` (`active` / `draft` / `disabled`) et un radio tri-état dans le formulaire PR-05, mais **sans préconditions de transition** : un producteur peut publier (`status = 'active'`) un produit sans description, sans photo, avec un stock à 0. KAN-22 a ajouté le statut dérivé `Épuisé` (`stock = 0 && status = 'active'`) à l'affichage de la card via le helper `getStockDisplayState`, mais sans tab de filtre dédié dans la liste.
+
+KAN-23 ferme la boucle : (a) règles de transition appliquées côté core avec erreurs typées par précondition manquante (subtask KAN-76), (b) tab « Épuisés » ajouté aux filtres avec décompte serveur (subtask KAN-77), (c) menu kebab `product-menu-btn` câblé pour les quick actions de transition depuis la card du catalogue. Aucune migration DB, aucun event Inngest.
+
+## Périmètre technique
+
+**In scope :**
+
+- Nouveau use case `transitionProductStatus(productId, targetStatus, ownerUserId)` dans `packages/core/src/product/` : valide la transition (graphe `draft ↔ active ↔ disabled` + `draft → disabled`), applique les préconditions de publication, retourne le snapshot mis à jour. Erreurs typées dédiées (cf. design.md).
+- Préconditions de publication (`draft → active` et `disabled → active`) : `name` non vide, `description` non null et non vide, `unit_price_cents > 0` (déjà CHECK DB), `stock > 0`, `photos` non vide (`jsonb_array_length ≥ 1`), `availability_to` non échue (si renseignée).
+- Nouveau endpoint `POST /api/v1/producer/products/[id]/status` body `{ status: 'active' | 'draft' | 'disabled' }`. Sémantique d'action séparée du `PATCH` CRUD pour avoir des erreurs typées propres et un point d'instrumentation futur.
+- Filtre serveur « Épuisés » : query param `status='sold_out'` côté `GET /api/v1/producer/products` se traduit par `WHERE status = 'active' AND stock = 0 AND deleted_at IS NULL`. Décompte serveur dans la response (`{ items, nextCursor, counts: { all, active, draft, disabled, sold_out } }`).
+- UI catalogue PR-04 :
+  - Tab « Épuisés » ajouté à `<CatalogueFilters />` avec compteur.
+  - Menu kebab `product-menu-btn` câblé : actions « Activer », « Mettre en brouillon », « Désactiver » selon le statut courant + « Supprimer » (déjà câblée par KAN-20). Toast succès / erreur. Re-fetch de la liste après transition.
+  - Si la transition échoue pour précondition manquante (ex : pas de photo) → toast d'erreur + lien « Compléter la fiche » qui ouvre la page d'édition avec un message inline.
+- UI formulaire PR-05 :
+  - Section 5 « Visibilité » : message inline sous le radio `Actif` listant les préconditions manquantes, désactive le bouton « Enregistrer » uniquement quand l'utilisateur tente de passer en `Actif` avec préconditions non remplies (autres statuts toujours enregistrables).
+  - À la soumission `PATCH` avec `status = 'active'` qui échoue côté API, afficher l'erreur typée mappée à un message localisé.
+- Mise à jour du commentaire de tête du `<ProductCard />` et du `getStockDisplayState` : pas de changement de logique mais documentation que `sold_out` peut désormais arriver comme valeur de filtre `?status=`.
+
+**Out of scope (cette US) :**
+
+- **Migration DB** : aucune. L'enum reste `active | draft | disabled`. `sold_out` est purement dérivé à l'affichage et au filtrage (cf. décision KAN-22 confirmée).
+- **Gating catalogue acheteur sur stock = 0** : reste KAN-28. La RLS `products_select_public` n'est pas touchée — un produit `active, stock = 0` reste visible à l'acheteur tant que KAN-28 ne décide pas du masquage / wishlist.
+- **Notifications de transition** (« votre produit a été publié », « stock épuisé ») : reste KAN-56. Pas d'event Inngest émis ici.
+- **Auditabilité / table `product_events`** : pas de table d'événements produit au MVP. La traçabilité des transitions est différée à un éventuel module modération (KAN-59) ou à une décision post-MVP.
+- **Modération admin** (forcer `disabled` côté back-office) : KAN-59.
+- **Auto-désactivation par jobs** (ex : fenêtre `availability_to` dépassée → bascule `active → disabled`) : différé post-MVP. Au MVP, un produit hors fenêtre est filtré par la RLS publique mais reste `active` côté producteur (lui reste responsable de basculer manuellement).
+- **Workflow équivalent côté mission / offre** : autre épic.
+- **Mobile** : non livré (cohérent KAN-20/21/22).
+
+## Hypothèses
+
+- **Graphe de transitions retenu** : `draft ↔ active`, `active ↔ disabled`, `draft → disabled`, `disabled → draft`. Tous les chemins sont autorisés ; seules les transitions **vers `active`** ont des préconditions. La décision est libérale côté retour en `draft` (un producteur peut toujours dépublier un produit). À arbitrer si on souhaite verrouiller `disabled → draft` (peu probable utile).
+- **Description requise pour publication** : on exige `description` non null **et** non vide après trim. Pas de longueur minimum imposée — la maquette PR-05 n'en fixe pas, et imposer un seuil arbitraire (ex : 20 chars) ajouterait une friction sans gain produit clair. À pointer en review si désaccord.
+- **Stock requis pour publication** : `stock > 0`. On refuse de publier un produit dont le badge serait immédiatement « Épuisé » à la première lecture — l'expérience producteur le veut. Conséquence : si le stock tombe à 0 après publication, le produit **reste** `active` (badge dérivé `Épuisé` côté UI, RLS publique inchangée). Cohérent avec KAN-22.
+- **Photos requises pour publication** : au moins 1 photo (KAN-21 livré). Cohérent avec le ton de la note pédagogique du panneau preview PR-05 (« Ajoutez une photo pour la confiance »).
+- **Endpoint dédié `…/status`** plutôt qu'un `PATCH` champ unique : un endpoint d'action expose une erreur métier claire (`PRODUCT_PUBLISH_MISSING_PHOTOS`), tandis qu'un `PATCH` générique renvoie un `VALIDATION_ERROR` global. Sans surcoût significatif (le handler reste 15-30 lignes).
+- **Pas de validation côté `PATCH /[id]`** sur le champ `status` : le `PATCH` accepte toujours `status` en input (cohérent avec ce qui est livré KAN-20), mais le serveur **route en interne** l'update via le use case `transitionProductStatus` si le statut change. Évite la divergence entre les deux chemins d'API. À discuter — alternative : interdire `status` dans le `PATCH` et forcer le client à passer par `…/status` (plus strict, casse possible avec le formulaire existant).
+- **Filtre serveur `sold_out`** : implémenté comme une **valeur additionnelle** du query param `status` (`?status=sold_out`) plutôt qu'un nouveau param dédié. Cohérent avec l'enum dérivé. Côté Zod : `status: z.enum(['all','active','draft','disabled','sold_out']).optional()`.
+- **Décompte serveur des tabs** : retourné dans la réponse `GET /producer/products` pour éviter 5 requêtes parallèles. Comptés sur `WHERE producer_user_id = auth.uid() AND deleted_at IS NULL` puis groupés par `status` + un `sold_out` calculé.
+- **Contradiction documentée avec KAN-22** : KAN-22 avait écrit « Pas de nouveau tab de filtre Épuisés ». KAN-23 introduit ce tab car le subtask Jira KAN-77 le demande explicitement (« Actif / Brouillon / Désactivé / Épuisé »). À mentionner dans le `tasks.md` et le journal §18 d'ARCHITECTURE.md si jugé structurant.
+- **Quick actions card** : trois actions max visibles dans le menu kebab selon le statut courant (ex : si `active` → « Mettre en brouillon » + « Désactiver » + « Supprimer »). Évite la cacophonie de 4 actions toujours visibles.

--- a/specs/KAN-23/tasks.md
+++ b/specs/KAN-23/tasks.md
@@ -1,0 +1,45 @@
+# Tâches techniques internes — KAN-23 Statuts produit
+
+> Ces tâches ne sont pas dans Jira. Setup, migrations, refacto, helpers partagés, seeds, configuration — tout ce qui n'a pas vocation à être tracké comme livrable produit.
+>
+> Subtasks Jira existantes (rappel — ne pas dupliquer ici) :
+> - KAN-76 : Passer un produit de Brouillon à Actif ou le Désactiver temporairement
+> - KAN-77 : Visualiser la liste des produits avec leur statut (Actif / Brouillon / Désactivé / Épuisé)
+
+## Tâches
+
+- [ ] Helper pur `getPublishPreconditions(product) → { ok: boolean, missing: ('name'|'description'|'price'|'stock'|'photos'|'availability')[] }` dans `packages/core/src/product/publish-preconditions.ts` + tests (couvrir chaque précondition + agrégat). Export depuis `packages/core/src/product/index.ts`.
+- [ ] Use case `transitionProductStatus` dans `packages/core/src/product/transition-product-status.ts` :
+  - Signature `(ctx, { productId, targetStatus, ownerUserId })` cohérente avec `updateProduct`.
+  - Fetch produit owner (sinon `PRODUCT_NOT_FOUND` ou `PRODUCT_FORBIDDEN`).
+  - Vérifier graphe de transitions ; refuser no-op et statuts inconnus avec `PRODUCT_TRANSITION_INVALID`.
+  - Si `targetStatus = 'active'` : appliquer `getPublishPreconditions` ; si manquant, retourner `PRODUCT_TRANSITION_INVALID` avec `details.missing`.
+  - Update DB via `productsRepo.update({ status })`.
+- [ ] Erreurs typées dans `packages/core/src/product/errors.ts` (ou équivalent) : `PRODUCT_TRANSITION_INVALID` (+ un champ `details.missing?: string[]`).
+- [ ] Schemas Zod :
+  - [ ] `packages/contracts/src/product/transition-status.ts` (input du nouvel endpoint).
+  - [ ] Étendre `packages/contracts/src/product/list.ts` : `status` accepte `'sold_out'`, ajouter `counts` à la response.
+  - [ ] Tests Zod associés.
+- [ ] Repo `packages/db/src/products/repo.ts` :
+  - [ ] `findByOwner` : accepter `status = 'sold_out'` (traduit en `WHERE status = 'active' AND stock = 0`).
+  - [ ] Nouvelle méthode `countByOwnerGroupedByStatus(ownerUserId)` retournant `{ all, active, draft, disabled, sold_out }` en une seule requête (`COUNT(*) FILTER`).
+- [ ] Route handler `apps/web/app/api/v1/producer/products/[id]/status/route.ts` :
+  - [ ] `POST` valide Zod input, appelle `transitionProductStatus`, mappe les erreurs typées en statuts HTTP (cf. ARCHITECTURE §4.3).
+- [ ] Étendre `apps/web/app/api/v1/producer/products/route.ts` (`GET`) : accepter `status=sold_out`, retourner `counts`.
+- [ ] Décision technique dans le handler `PATCH /[id]` : si `status` est présent dans le body et diffère de l'actuel, **router en interne** vers `transitionProductStatus` après avoir appliqué les autres champs. Documenter en commentaire de tête du fichier.
+- [ ] Adapter web `apps/web/lib/products/adapter.ts` : nouvelle méthode `transitionStatus(productId, targetStatus)` qui appelle le nouveau endpoint.
+- [ ] Composants :
+  - [ ] `apps/web/components/producer/catalogue/catalogue-filters.tsx` : ajout du tab « Épuisés » avec compteur, style orange pour actif.
+  - [ ] `apps/web/components/producer/catalogue/product-card.tsx` : câblage du menu kebab via `<DropdownMenu />` (shadcn), actions dynamiques selon le statut, toast succès / erreur, lien « Compléter la fiche » si précondition manquante.
+  - [ ] `apps/web/components/producer/catalogue/product-form.tsx` : sous le radio `Actif`, bloc « Pour publier, il faut » alimenté par `getPublishPreconditions`. Lecture de `?focus=publish` au mount pour scroll + highlight section 5.
+  - [ ] (Optionnel) Nouveau composant `<PublishPreconditionsList />` interne au form ou dans un fichier dédié.
+- [ ] Page liste : passer `response.counts` à `<CatalogueFilters />` ; re-fetch après transition.
+- [ ] Tests E2E `apps/web/e2e/producer-catalogue.spec.ts` (étendu) : 5 scénarios listés dans design.md.
+- [ ] Mettre à jour `ARCHITECTURE.md` §18 : nouvelle entrée datée pour acter (a) le pattern « endpoint d'action `…/status` séparé du CRUD », (b) la contradiction documentée avec la décision KAN-22 (« pas de tab Épuisés ») et sa justification (subtask KAN-77).
+- [ ] Mise à jour `produit/jira_mapping.md` (statut KAN-23 → `Examiner` au merge implémentation) — fait par le commit de mapping post-merge selon le cas B de CLAUDE.md, pas ici.
+- [ ] (Différé KAN-56) Émission d'un éventuel event `product.status_changed` pour les notifications de transition.
+- [ ] (Différé post-MVP) Job Inngest d'auto-désactivation pour les produits dont `availability_to` est échue.
+
+## Checklist pre-merge
+
+Voir ARCHITECTURE.md §14.3 — ne pas dupliquer ici.


### PR DESCRIPTION
## Cadrage technique KAN-23 — Statuts produit

Trois fichiers courts dans `specs/KAN-23/` :

- [`proposal.md`](specs/KAN-23/proposal.md) — pourquoi, périmètre, hypothèses
- [`design.md`](specs/KAN-23/design.md) — packages, API, UI, risques, tests
- [`tasks.md`](specs/KAN-23/tasks.md) — tâches techniques internes

## Résumé

KAN-23 ferme la boucle des statuts produit posée par KAN-20/22 :

- Use case `transitionProductStatus` avec préconditions de publication (nom, description, prix > 0, stock > 0, ≥ 1 photo, fenêtre valide) et erreurs typées par précondition.
- Endpoint d'action dédié `POST /api/v1/producer/products/[id]/status` (séparé du `PATCH` CRUD).
- Tab « Épuisés » dans `<CatalogueFilters />` avec décompte serveur (`counts`), filtre `status='sold_out'` traduit en `WHERE status = 'active' AND stock = 0` côté repo.
- Menu kebab du `<ProductCard />` câblé avec quick actions de transition selon le statut courant.
- Bloc inline « Pour publier, il faut » dans le formulaire PR-05 section 5, alimenté par un helper pur `getPublishPreconditions`.

Aucune migration DB, aucun event Inngest, pas de changement RLS.

## Points d'arbitrage notés

- Description requise non vide pour publication, **sans longueur minimum** (à valider en review).
- Contradiction documentée avec la décision KAN-22 (« pas de tab Épuisés ») — justifiée par le subtask KAN-77 qui le demande explicitement.
- Choix d'un endpoint d'action `…/status` séparé du `PATCH` CRUD (trade-off détaillé dans `proposal.md` § Hypothèses).

## Subtasks Jira couvertes

- KAN-76 — Passer un produit de Brouillon à Actif ou le Désactiver temporairement
- KAN-77 — Visualiser la liste des produits avec leur statut (Actif / Brouillon / Désactivé / Épuisé)

## Workflow

Auto-merge squash activé à la création. Au merge :
- Transition Jira `Ideas → À faire` (id `21`).
- PR mapping `Mapping Jira : KAN-23 en À faire`.
- Enchaînement automatique sur `/implement KAN-23`.

Réf : `https://erkulaws.atlassian.net/browse/KAN-23`


---
_Generated by [Claude Code](https://claude.ai/code/session_01N61KgCKfUjBuGtLcCdoKyr)_