### PR TITLE
[KAN-21] afficher la photo de couverture dans la liste catalogue

### DIFF
--- a/apps/web/app/producer/catalogue/catalogue-client.tsx
+++ b/apps/web/app/producer/catalogue/catalogue-client.tsx
@@ -20,6 +20,7 @@ type Item = Pick<
   | "availability_from"
   | "availability_to"
   | "status"
+  | "photos"
 >
 
 /**
@@ -86,6 +87,7 @@ export function CatalogueClient({
         availability_from: p.availability_from,
         availability_to: p.availability_to,
         status: p.status,
+        coverPhotoUrl: p.photos[0]?.url ?? null,
       }))
   }, [items, status, q])
 

--- a/apps/web/components/producer/catalogue/product-card.tsx
+++ b/apps/web/components/producer/catalogue/product-card.tsx
@@ -41,6 +41,8 @@ export type ProductCardItem = {
   availability_from: string | null
   availability_to: string | null
   status: ProductStatus
+  /** URL publique de la photo de couverture (`photos[0].url`) — KAN-21. */
+  coverPhotoUrl: string | null
 }
 
 export function ProductCard({ product }: { product: ProductCardItem }) {
@@ -146,11 +148,23 @@ export function ProductCard({ product }: { product: ProductCardItem }) {
       className={`group flex flex-col overflow-hidden rounded-lg border border-cream-200 bg-white transition-all hover:-translate-y-0.5 hover:border-green-300 hover:shadow-elevated ${dimClass}`}
     >
       <div
-        className={`relative flex h-[150px] items-center justify-center bg-gradient-to-br ${gradientForCategory(product.category)}`}
+        className={`relative flex h-[150px] items-center justify-center overflow-hidden bg-gradient-to-br ${gradientForCategory(product.category)}`}
       >
-        <span className="select-none text-6xl opacity-70" aria-hidden="true">
-          {emoji}
-        </span>
+        {product.coverPhotoUrl ? (
+          /* eslint-disable-next-line @next/next/no-img-element */
+          <img
+            src={product.coverPhotoUrl}
+            alt={product.name}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <span
+            className="select-none text-6xl opacity-70"
+            aria-hidden="true"
+          >
+            {emoji}
+          </span>
+        )}
         <span
           className={`absolute left-2.5 top-2.5 inline-flex items-center gap-1.5 rounded-pill border px-2 py-0.5 text-[10.5px] font-bold uppercase tracking-wider ${statusBadgeClass(displayStatus)}`}
         >


### PR DESCRIPTION
## Fix KAN-21 — afficher la photo de couverture dans la liste catalogue

Le composant `<ProductCard />` (PR-04) affichait systématiquement l'emoji catégorie sur fond gradient, même quand le produit avait une photo uploadée via KAN-21. La liste `/producer/catalogue` ignorait `photos[0].url`.

Trois modifs :

- `ProductCardItem` gagne `coverPhotoUrl: string | null`
- `<ProductCard />` rend ``&lt;img src={coverPhotoUrl} className="object-cover"&gt;`` quand présent, sinon fallback emoji
- `catalogue-client.tsx` élargit le `Pick<>` pour inclure `photos` et mappe `coverPhotoUrl: p.photos[0]?.url ?? null`

Cohérent avec le pattern déjà appliqué dans `<ProductFormPreview />` (page édition).

### Test

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (1 warning préexistant non lié)
- 27 fichiers de tests, 206 tests verts


---
_Generated by [Claude Code](https://claude.ai/code/session_016VGdVBWktLN5YdxZW6SjD3)_