### PR TITLE
specs KAN-24 — Labels & catégories

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -31,7 +31,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | PR-02 Onboarding Stripe Connect | `pr-02-onboarding-stripe.html` | KAN-16 (Onboarding Stripe Connect) — [Cadrage tech](specs/KAN-16/) | KAN-62, KAN-158 (polish UX restricted) |
 | PR-03 Dashboard | `pr-03-dashboard.html` | KAN-18 (Tableau de bord producteur) — [Cadrage tech](specs/KAN-18/) | KAN-56 |
 | PR-04 Catalogue produits | `pr-04-catalogue.html` | KAN-20 (Création & édition produit) — [Cadrage tech](specs/KAN-20/) | KAN-23 (Statuts produit) — [Cadrage tech](specs/KAN-23/) |
-| PR-05 Création / édition produit | `pr-05-edition-produit.html` | KAN-20 (Création & édition produit) — [Cadrage tech](specs/KAN-20/) | KAN-21 (Photos) — [Cadrage tech](specs/KAN-21/), KAN-22 (Stock) — [Cadrage tech](specs/KAN-22/), KAN-24 (Labels & catégories) |
+| PR-05 Création / édition produit | `pr-05-edition-produit.html` | KAN-20 (Création & édition produit) — [Cadrage tech](specs/KAN-20/) | KAN-21 (Photos) — [Cadrage tech](specs/KAN-21/), KAN-22 (Stock) — [Cadrage tech](specs/KAN-22/), KAN-24 (Labels & catégories) — [Cadrage tech](specs/KAN-24/) |
 | PR-06 Récupération à venir | `pr-06-recuperation.html` | KAN-46 (QR Pickup), KAN-47 (Checklist remise producteur) | KAN-45 |
 | PR-07 Historique ventes | `pr-07-historique-ventes.html` | KAN-19 (Historique ventes) — [Cadrage tech](specs/KAN-19/) | KAN-36 (Factures PDF) |
 | PR-08 Profil public producteur | `pr-08-profil-public.html` | KAN-17 (Informations profil & ferme) — [Cadrage tech](specs/KAN-17/) | KAN-53 (Profils publics & avis), KAN-63, KAN-64, KAN-65, KAN-66 |
@@ -121,7 +121,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | KAN-21 | Feature | Examiner | Gestion photos — [Cadrage tech](specs/KAN-21/) — mergé sur main (PR #34) |
 | KAN-22 | Feature | Examiner | Stock & alertes — [Cadrage tech](specs/KAN-22/) — mergé sur main (PR #38) |
 | KAN-23 | Feature | Examiner | Statuts produit — [Cadrage tech](specs/KAN-23/) — mergé sur main (PR #42) |
-| KAN-24 | Feature | Ideas | Labels & catégories |
+| KAN-24 | Feature | Ideas | Labels & catégories — [Cadrage tech](specs/KAN-24/) |
 
 ### KAN-6 — Profil Acheteur
 

--- a/specs/KAN-24/design.md
+++ b/specs/KAN-24/design.md
@@ -1,0 +1,87 @@
+# Conception technique — KAN-24 Labels & catégories
+
+## Vue d'ensemble
+
+Câblage applicatif d'un champ déjà présent en DB, avec une migration de type. Le mouvement principal : figer la whitelist `product_label` (en suspens depuis KAN-20), swap la colonne `products.labels` de `text[]` → `product_label[]`, puis propager l'enum à travers contrats Zod → use cases → repo → formulaire PR-05 → affichage chips (card + preview). La catégorie est hors périmètre (livrée par KAN-20).
+
+Pas de state machine, pas d'event Inngest. Seule nouveauté DB : un enum + un `ALTER COLUMN … TYPE` avec cast.
+
+## Packages touchés
+
+- [x] `packages/contracts` — `shared.ts` : ajout `PRODUCT_LABELS`, `ProductLabel`, `PRODUCT_LABEL_FR`. `create.ts` / `update.ts` / `snapshot.ts` : `labels: z.array(ProductLabel).max(10)`.
+- [x] `packages/core` — use cases `createProduct` / `updateProduct` : le champ est déjà propagé (`labels: data.labels ?? []`) ; vérifier le typage, ajouter couverture test.
+- [x] `packages/db` — `types.ts` : `labels` passe de `string[]` à `ProductLabel[]` sur `Row` / `Insert` / `Update`. Vérifier le mapping repo (déjà générique).
+- [x] `apps/web` — `product-form.tsx` (sélecteur labels multi en chips, section 1), `product-card.tsx` + `product-form-preview.tsx` (chips), réutilisation du pattern chips du profil producteur.
+- [ ] `apps/mobile` — hors scope.
+- [ ] `packages/jobs` — aucun event.
+- [x] `supabase/migrations` — nouvelle migration : `CREATE TYPE product_label` + swap colonne.
+- [ ] `supabase/policies` — aucun changement RLS.
+- [ ] `packages/ui-web` — non promu (cohérent KAN-20/21/22/23).
+
+## Modèle de données
+
+Enum `product_label` (D1 — union pertinente) :
+
+```
+bio_ab, demeter, nature_et_progres, label_rouge, hve_3, producteur_fermier
+```
+
+Nouvelle migration `supabase/migrations/<ts>_product_labels_enum.sql` :
+
+- `CREATE TYPE public.product_label AS ENUM (…)` (garde `IF NOT EXISTS` via `DO $$`).
+- `ALTER TABLE public.products ALTER COLUMN labels TYPE public.product_label[] USING labels::public.product_label[];` — la colonne ne contient que `'{}'` en prod (feature non exposée), cast sans risque. Conserver `NOT NULL DEFAULT '{}'`.
+- Mettre à jour le `COMMENT ON COLUMN products.labels` (retirer la mention « text[] au MVP de KAN-20 / KAN-24 swap », documenter l'enum + la non-fusion avec `producer_label`).
+- Rollback documenté : `ALTER COLUMN labels TYPE text[]` + `DROP TYPE product_label`.
+- Idempotence : garde sur le type, swap conditionnel (ne pas re-caster si déjà `product_label[]`).
+
+Référence : `supabase/migrations/20260518000000_create_products.sql:104,164-166`, ARCHITECTURE.md §5, §18 entrée 1.22.
+
+## API / Endpoints
+
+Aucun nouvel endpoint. Les endpoints existants resserrent la validation :
+
+- `POST /api/v1/producer/products` et `PATCH /api/v1/producer/products/[id]` : `labels` n'accepte plus que des valeurs de la whitelist `product_label` (au lieu de chaînes libres). Un label hors whitelist → `PRODUCT_VALIDATION_FAILED` (Zod, cf. shared.ts).
+- `GET` retourne déjà `labels` via le snapshot.
+
+Pas de nouveau code d'erreur.
+
+## Impact state machine / events
+
+Aucun. Pas de transition mission, pas d'event Inngest (cohérent KAN-22).
+
+## Dépendances
+
+Services externes : aucun. Pas de mise à jour `tech/setup.md`.
+
+Internes :
+- Table `products` (KAN-20) — colonne `labels` déjà présente.
+- Pattern chips multi-select du profil producteur (`PRODUCER_LABELS` / `PRODUCER_LABEL_FR`) — modèle UI à répliquer pour les labels produit.
+- `<ProductForm />`, `<ProductCard />`, `<ProductFormPreview />` (KAN-20/21/22).
+
+## État UI
+
+Référence : `DESIGN.md` (tokens, breakpoints), maquette PR-05 section 1.
+
+**Formulaire PR-05 — Section 1 « Identité » :**
+- Ajouter le champ « Labels / certifications (optionnel) » après la catégorie.
+- Rendu : **chips multi-select** (D2) alimenté par `PRODUCT_LABELS` + `PRODUCT_LABEL_FR`. Déviation vs le `select` mono-valeur de la maquette → à consigner dans `notes.md` à l'implémentation.
+- État vide accepté (`labels: []`).
+
+**Card PR-04 + preview PR-05 :**
+- Afficher les labels en petits chips sobres (token vert clair) sous la catégorie. Pas de chip si `labels` vide.
+- Desktop + mobile (responsive obligatoire).
+
+## Risques techniques
+
+- **Cast de migration** : sûr tant que la colonne ne contient que `'{}'` (feature jamais exposée). Si des données de test contiennent des chaînes hors whitelist, le cast échoue → vérifier `SELECT DISTINCT unnest(labels) FROM products` avant apply. Au besoin, nettoyer dans la migration.
+- **Cohérence avec `ProducerLabel`** : deux enums proches mais distincts. Documenter en commentaire pourquoi ils ne sont pas fusionnés (D1) pour éviter une fausse duplication aux yeux d'un reviewer.
+- **Déviation maquette single → multi** : assumée (D2), consignée dans `notes.md`.
+
+## Tests envisagés
+
+Référence : ARCHITECTURE.md §10.
+
+- **Unit contracts** (`product/{create,update}.test.ts`) : label whitelisté accepté (`["bio_ab"]`), refusé (`["not-a-label"]`, chaîne libre), `> 10` refusé, `[]` accepté. Mettre à jour les fixtures qui utilisent `labels: ["Bio AB"]` (chaîne libre → clé enum `bio_ab`).
+- **Unit core** (`create-product.test.ts` / `update-product.test.ts`) : propagation `labels`, réinitialisation à `[]`.
+- **Unit display** : helper de rendu chips (libellé FR, ordre stable).
+- **E2E web Playwright** : déféré (fixtures auth producteur indisponibles, cohérent KAN-20→23).

--- a/specs/KAN-24/proposal.md
+++ b/specs/KAN-24/proposal.md
@@ -1,0 +1,41 @@
+# Cadrage — KAN-24 Labels & catégories
+
+## Liens
+
+- Jira : https://erkulaws.atlassian.net/browse/KAN-24
+- Epic : KAN-5 Catalogue
+- Maquette : design/maquettes/producteur/pr-05-edition-produit.html (section 1 « Identité », champs Catégorie + Bio/Label)
+- PRD : §10.3 (sitemap producteur, écran PR-05)
+- ARCHITECTURE : §5 (DB — swap enum), §3 (contrats Zod), §10 (tests), §14 (playbook), §18 (journal — entrée à ajouter)
+
+## Pourquoi (côté tech)
+
+KAN-20 a livré la table `products` avec toutes les colonnes de l'épic pré-créées. La **catégorie** est déjà entièrement câblée (enum `product_category`, select requis, libellés FR + emoji). KAN-24 finit le câblage des **labels / certifications** : la colonne `labels` est aujourd'hui un `text[] DEFAULT '{}'` non exposé dans l'UI. La décision documentée (ARCHITECTURE §18 entrée 1.22, commentaires de migration) prévoit que KAN-24 fige la whitelist en enum `product_label`, swap la colonne `text[]` → `product_label[]`, propage le type dans les contrats / use cases / repo, et ajoute le sélecteur de labels manquant au formulaire PR-05.
+
+## Périmètre technique
+
+**In scope :**
+
+- Définir l'enum `product_label` (whitelist figée — voir Décisions D1) côté DB + contrats.
+- Migration : swap `products.labels` de `text[]` → `product_label[]` (cast des valeurs existantes, `NOT NULL DEFAULT '{}'`).
+- Contrats Zod : remplacer `labels: z.array(z.string()…)` par `z.array(ProductLabel)` dans `create.ts` / `update.ts` / `snapshot.ts`, ajouter `PRODUCT_LABEL_FR`.
+- UI PR-05 : ajouter le sélecteur de labels (section 1) absent du formulaire actuel — multi-select en chips (voir Décisions D2).
+- Affichage des labels en chips sur la card produit (PR-04) et la preview voisin (PR-05).
+- Tests : unit contracts (whitelist acceptée / refusée), unit core (propagation), unit display.
+
+**Out of scope (cette US) :**
+
+- **Catégorie** : déjà livrée par KAN-20 (rien à refaire).
+- Filtre par catégorie / label dans le catalogue acheteur (KAN-28) ou producteur.
+- Gestion d'une table `categories` dynamique (post-MVP, mentionnée dans le commentaire SQL de KAN-20).
+- Mobile (cohérent KAN-20/21/22/23).
+
+## Décisions (arbitrées 2026-05-20)
+
+- **D1 — whitelist `product_label`** : enum dédié = union pertinente de la maquette PR-05 (`Bio AB / Demeter / Nature & Progrès / Label Rouge`) et de `PRODUCER_LABELS` (`bio_ab / demeter / nature_et_progres / hve_3 / producteur_fermier`) → `bio_ab, demeter, nature_et_progres, label_rouge, hve_3, producteur_fermier` (6 valeurs). Enum **distinct** de `ProducerLabel` (label produit ≠ certification ferme, même si recouvrement) — à documenter en commentaire pour éviter une fausse duplication.
+- **D2 — multi-select** : un produit peut cumuler plusieurs labels (ex : Bio AB + Demeter), conforme à la colonne `text[]`/array. Rendu chips multi-select (pattern du profil producteur). La maquette PR-05 montre un `select` mono-valeur — déviation assumée, à consigner dans `specs/KAN-24/notes.md` au moment de l'implémentation.
+
+## Hypothèses
+
+- Pas d'event Inngest, pas d'impact state machine, pas de nouveau service externe.
+- La colonne `labels` ne contient que `'{}'` en base (feature jamais exposée) — cast de migration sans risque.

--- a/specs/KAN-24/tasks.md
+++ b/specs/KAN-24/tasks.md
@@ -1,0 +1,21 @@
+# Tâches techniques internes — KAN-24 Labels & catégories
+
+> Ces tâches ne sont pas dans Jira. Setup, migrations, refacto, helpers partagés, seeds, configuration — tout ce qui n'a pas vocation à être tracké comme livrable produit.
+>
+> Subtasks Jira existantes (rappel — ne pas dupliquer ici) :
+> (aucune)
+
+## Tâches
+
+- [ ] Consigner les décisions D1 (whitelist) et D2 (multi-select, déviation maquette) dans `specs/KAN-24/notes.md`.
+- [ ] Migration `<ts>_product_labels_enum.sql` : `CREATE TYPE product_label` (6 valeurs) + swap colonne `labels` + mise à jour du `COMMENT`.
+- [ ] Vérifier l'absence de valeurs hors whitelist en base avant le cast.
+- [ ] Contrats : `PRODUCT_LABELS` / `ProductLabel` / `PRODUCT_LABEL_FR` dans `shared.ts` ; resserrer `labels` dans `create.ts` / `update.ts` / `snapshot.ts`.
+- [ ] `packages/db/types.ts` : typer `labels` en `ProductLabel[]`.
+- [ ] Mettre à jour les fixtures de test utilisant `labels: ["Bio AB"]` (chaîne libre → clé enum).
+- [ ] UI : sélecteur labels multi en chips dans `product-form.tsx` + chips d'affichage dans `product-card.tsx` / `product-form-preview.tsx`.
+- [ ] Ajouter l'entrée au journal ARCHITECTURE.md §18 (swap enum — décision structurante).
+
+## Checklist pre-merge
+
+Voir ARCHITECTURE.md §14.3 — ne pas dupliquer ici.


### PR DESCRIPTION
## Cadrage technique KAN-24 — Labels & catégories

Ouverture du cadrage de [KAN-24](https://erkulaws.atlassian.net/browse/KAN-24) (épic KAN-5 Catalogue, écran PR-05).

Trois specs dans `specs/KAN-24/` :
- `proposal.md` — périmètre, décisions arbitrées
- `design.md` — conception technique
- `tasks.md` — tâches techniques internes

### Résumé
La **catégorie** est déjà entièrement câblée par KAN-20. KAN-24 finit les **labels** : swap de la colonne `products.labels` de `text[]` → enum `product_label`, propagation dans les contrats / use cases / repo, et ajout du sélecteur de labels manquant au formulaire PR-05.

### Décisions arbitrées
- **D1** : whitelist `product_label` = union pertinente maquette + producteur → `bio_ab, demeter, nature_et_progres, label_rouge, hve_3, producteur_fermier` (enum distinct de `producer_label`).
- **D2** : multi-select en chips (un produit peut cumuler plusieurs labels). Déviation assumée vs le `select` mono-valeur de la maquette.

Aucun event Inngest, aucun impact state machine, aucun nouveau service externe.

https://claude.ai/code/session_01JQsJS9K5yRP5ZN5axUExZo

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQsJS9K5yRP5ZN5axUExZo)_