### PR TITLE
Mapping Jira : KAN-24 en À faire (merge cadrage PR #47)

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -9,7 +9,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 - **13 épics** (KAN-1, KAN-4 → KAN-15) — un épic par grand domaine fonctionnel
 - **50 features cataloguées** (KAN-2, KAN-3 sous KAN-1 ; KAN-16 → KAN-158 sous les autres épics — voir tables par épic ci-dessous)
 - **Subtasks** : voir le catalogue par épic ci-dessous. Le mapping peut être incomplet pour les subtasks les plus récentes — Jira fait foi pour la liste exhaustive.
-- État au 2026-05-18 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-17 *Terminé* (mergé sur `main` — PR #18, cadrage `specs/KAN-17/`) ; KAN-18 *Terminé* (mergé sur `main` — PR #21, cadrage `specs/KAN-18/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; KAN-19 *Examiner* (mergé sur `main` — PR #25, cadrage `specs/KAN-19/`) ; KAN-20 *Examiner* (mergé sur `main` — PR #30, cadrage `specs/KAN-20/`) ; KAN-21 *Examiner* (mergé sur `main` — PR #34, cadrage `specs/KAN-21/`) ; KAN-22 *Examiner* (mergé sur `main` — PR #38, cadrage `specs/KAN-22/`) ; KAN-23 *Examiner* (mergé sur `main` — PR #42, cadrage `specs/KAN-23/`) ; autres *Ideas*
+- État au 2026-05-20 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-17 *Terminé* (mergé sur `main` — PR #18, cadrage `specs/KAN-17/`) ; KAN-18 *Terminé* (mergé sur `main` — PR #21, cadrage `specs/KAN-18/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; KAN-19 *Examiner* (mergé sur `main` — PR #25, cadrage `specs/KAN-19/`) ; KAN-20 *Examiner* (mergé sur `main` — PR #30, cadrage `specs/KAN-20/`) ; KAN-21 *Examiner* (mergé sur `main` — PR #34, cadrage `specs/KAN-21/`) ; KAN-22 *Examiner* (mergé sur `main` — PR #38, cadrage `specs/KAN-22/`) ; KAN-23 *Examiner* (mergé sur `main` — PR #42, cadrage `specs/KAN-23/`) ; KAN-24 *À faire* (cadrage mergé sur `main` — PR #47, `specs/KAN-24/`) ; autres *Ideas*
 - **Maquettes (2026-05-14)** : les 35 écrans des 3 parcours (Producteur, Acheteur, Rameneur) du sitemap PRD §10 sont maquettés. Restent à maquetter : transverses **TR-02** (centre notifications) et **TR-04** (signalement / litige) ; **TR-03** est couvert par `rm-09-chat.html`. Index navigable de toutes les maquettes : `design/maquettes/index.html`
 
 ## Convention de référencement
@@ -121,7 +121,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | KAN-21 | Feature | Examiner | Gestion photos — [Cadrage tech](specs/KAN-21/) — mergé sur main (PR #34) |
 | KAN-22 | Feature | Examiner | Stock & alertes — [Cadrage tech](specs/KAN-22/) — mergé sur main (PR #38) |
 | KAN-23 | Feature | Examiner | Statuts produit — [Cadrage tech](specs/KAN-23/) — mergé sur main (PR #42) |
-| KAN-24 | Feature | Ideas | Labels & catégories — [Cadrage tech](specs/KAN-24/) |
+| KAN-24 | Feature | À faire | Labels & catégories — [Cadrage tech](specs/KAN-24/) |
 
 ### KAN-6 — Profil Acheteur
 


### PR DESCRIPTION
Synchronisation du mapping après merge du cadrage KAN-24 (PR #47).

- KAN-24 : statut `Ideas` → `À faire` dans le catalogue KAN-5.
- Ligne « État au » mise à jour (2026-05-20).

https://claude.ai/code/session_01JQsJS9K5yRP5ZN5axUExZo

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQsJS9K5yRP5ZN5axUExZo)_