### PR TITLE
specs KAN-25 — Onboarding & zone

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -9,7 +9,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 - **13 épics** (KAN-1, KAN-4 → KAN-15) — un épic par grand domaine fonctionnel
 - **50 features cataloguées** (KAN-2, KAN-3 sous KAN-1 ; KAN-16 → KAN-158 sous les autres épics — voir tables par épic ci-dessous)
 - **Subtasks** : voir le catalogue par épic ci-dessous. Le mapping peut être incomplet pour les subtasks les plus récentes — Jira fait foi pour la liste exhaustive.
-- État au 2026-05-20 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-17 *Terminé* (mergé sur `main` — PR #18, cadrage `specs/KAN-17/`) ; KAN-18 *Terminé* (mergé sur `main` — PR #21, cadrage `specs/KAN-18/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; KAN-19 *Examiner* (mergé sur `main` — PR #25, cadrage `specs/KAN-19/`) ; KAN-20 *Examiner* (mergé sur `main` — PR #30, cadrage `specs/KAN-20/`) ; KAN-21 *Examiner* (mergé sur `main` — PR #34, cadrage `specs/KAN-21/`) ; KAN-22 *Examiner* (mergé sur `main` — PR #38, cadrage `specs/KAN-22/`) ; KAN-23 *Examiner* (mergé sur `main` — PR #42, cadrage `specs/KAN-23/`) ; KAN-24 *Examiner* (mergé sur `main` — PR #49, cadrage `specs/KAN-24/`) ; autres *Ideas*
+- État au 2026-05-22 : KAN-1 *Examiner* (épic Authentication entièrement livré côté features, à clôturer manuellement si souhaité) ; KAN-2 / KAN-3 / KAN-157 *Terminé* (mergés sur `main` — PRs #2/#3/#4/#5 pour KAN-2, #8 pour KAN-3, #9 pour KAN-157) ; KAN-16 *Terminé* (mergé sur `main` — PR #10, cadrage `specs/KAN-16/`) ; KAN-17 *Terminé* (mergé sur `main` — PR #18, cadrage `specs/KAN-17/`) ; KAN-18 *Terminé* (mergé sur `main` — PR #21, cadrage `specs/KAN-18/`) ; KAN-158 *Terminé* (mergé sur `main` — PR #15, cadrage `specs/KAN-158/`) ; KAN-19 *Examiner* (mergé sur `main` — PR #25, cadrage `specs/KAN-19/`) ; KAN-20 *Examiner* (mergé sur `main` — PR #30, cadrage `specs/KAN-20/`) ; KAN-21 *Examiner* (mergé sur `main` — PR #34, cadrage `specs/KAN-21/`) ; KAN-22 *Examiner* (mergé sur `main` — PR #38, cadrage `specs/KAN-22/`) ; KAN-23 *Examiner* (mergé sur `main` — PR #42, cadrage `specs/KAN-23/`) ; KAN-24 *Examiner* (mergé sur `main` — PR #49, cadrage `specs/KAN-24/`) ; KAN-25 *Ideas* (cadrage ouvert — `specs/KAN-25/`, PR cadrage en cours) ; autres *Ideas*
 - **Maquettes (2026-05-14)** : les 35 écrans des 3 parcours (Producteur, Acheteur, Rameneur) du sitemap PRD §10 sont maquettés. Restent à maquetter : transverses **TR-02** (centre notifications) et **TR-04** (signalement / litige) ; **TR-03** est couvert par `rm-09-chat.html`. Index navigable de toutes les maquettes : `design/maquettes/index.html`
 
 ## Convention de référencement
@@ -42,7 +42,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | Écran | Maquette | Ticket(s) Jira principal(aux) | Tickets liés |
 |-------|----------|-------------------------------|--------------|
 | AC-01 Inscription / connexion | `ac-01-authentication.html` | KAN-2 (Création de compte), KAN-3 (Connexion), KAN-157 (Récup. mot de passe) | [Cadrage KAN-2](specs/KAN-2/), [Cadrage KAN-3](specs/KAN-3/), [Cadrage KAN-157](specs/KAN-157/) |
-| AC-02 Onboarding | `ac-02-onboarding.html` | KAN-25 (Onboarding & zone), KAN-26 (Préférences catégories) | — |
+| AC-02 Onboarding | `ac-02-onboarding.html` | KAN-25 (Onboarding & zone), KAN-26 (Préférences catégories) | [Cadrage KAN-25](specs/KAN-25/) |
 | AC-03 Accueil | `ac-03-accueil.html` | KAN-28 (Catalogue filtré) | — |
 | AC-04 Catalogue parcourable | `ac-04-catalogue.html` | KAN-28 (Catalogue filtré) | KAN-29 (Zone non couverte) |
 | AC-05 Fiche produit | `ac-05-fiche-produit.html` | KAN-28 (Catalogue filtré) | KAN-30 (Wishlist privée) |
@@ -54,7 +54,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | AC-08bis Profil public producteur | `ac-08bis-profil-producteur.html` | KAN-53 (Profils publics & avis) | — |
 | AC-09 Historique commandes | `ac-09-historique.html` | KAN-27 (Historique commandes) | KAN-36 (Factures PDF) |
 | AC-10 Évaluation post-livraison | `ac-10-evaluation.html` | KAN-52 (Notation post-livraison) | — |
-| AC-11 Profil + paramètres | `ac-11-profil.html` | KAN-26 (Préférences catégories), KAN-25 (Onboarding & zone) | — |
+| AC-11 Profil + paramètres | `ac-11-profil.html` | KAN-26 (Préférences catégories), KAN-25 (Onboarding & zone) | [Cadrage KAN-25](specs/KAN-25/) |
 | AC-12 Zone non couverte | `ac-12-zone-non-couverte.html` | KAN-29 (Zone non couverte & liste d'attente) | — |
 
 ### Parcours Rameneur (§10.4 PRD)
@@ -128,7 +128,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | Ticket | Type | Statut | Résumé |
 |--------|------|--------|--------|
 | KAN-6 | Epic | Ideas | Profil Acheteur |
-| KAN-25 | Feature | Ideas | Onboarding & zone |
+| KAN-25 | Feature | Ideas | Onboarding & zone — [Cadrage tech](specs/KAN-25/) |
 | KAN-26 | Feature | Ideas | Préférences catégories |
 | KAN-27 | Feature | Ideas | Historique commandes |
 

--- a/specs/KAN-25/design.md
+++ b/specs/KAN-25/design.md
@@ -1,0 +1,106 @@
+# Conception technique — KAN-25 Onboarding & zone
+
+## Vue d'ensemble
+
+On introduit un profil acheteur minimal dans une table `buyer_profiles`
+(miroir du pattern `producers` de KAN-16) : une ligne par compte ayant le
+rôle acheteur, créée à la première soumission de zone. Le mouvement principal
+est côté `apps/web` (étape 1 du wizard AC-02 + section paramètres AC-11) +
+`packages/db` (repo upsert) + une migration Supabase posant la table, son
+`geography(Point)` indexé GIST et la RLS self-owned. Le composant
+`address-autocomplete.tsx` (KAN-17) est promu de `producer/` vers `forms/`
+pour être partagé entre producteur, acheteur et (plus tard) rameneur.
+
+## Packages touchés
+
+- [x] `packages/contracts` — `BuyerProfileInput` (nom, adresse label, ville, CP, lat, lng)
+- [x] `packages/core` — validation/normalisation zone, règle « zone obligatoire pour matching »
+- [x] `packages/db` — repo `buyerProfilesRepo.{ findByUserId, upsert }`, helper PostGIS (`ST_SetSRID(ST_MakePoint(lng,lat),4326)`)
+- [x] `apps/web` — étape 1 wizard `/onboarding/acheteur` + section zone dans paramètres (AC-11) + route handler(s) `app/api/v1/me/buyer-profile`
+- [ ] `apps/mobile` — différé (non scaffoldé)
+- [ ] `packages/jobs` — non applicable
+- [x] `supabase/migrations` — table `buyer_profiles` + index GIST
+- [x] `supabase/policies` — RLS `buyer_profiles` (self-owned)
+- [x] `packages/ui-web` — promotion `AddressAutocomplete` vers composant partagé (`forms/`) + éventuel `BuyerZoneForm`
+
+## Modèle de données
+
+Référence : ARCHITECTURE.md §5 et §7.
+
+Table `public.buyer_profiles` :
+
+- `user_id` (uuid, PK, FK → `public.users.id` ON DELETE CASCADE) — UNIQUE de fait (PK)
+- `display_name` (text) — nom d'affichage (cf. hypothèse nom à valider)
+- `address_label` (text) — label complet retourné par Adresse Gouv.fr
+- `city` (text), `postcode` (text)
+- `location` (`geography(Point, 4326)`, null tant que zone non saisie) — alimente le matching §7.2
+- `created_at`, `updated_at` (timestamptz, défaut `now()`)
+- `deleted_at` (timestamptz, null) — soft delete RGPD
+
+Index : `GIST (location)` pour `ST_DWithin` (ARCHITECTURE §5 « Index GIST sur géo »,
+§7.2). Trigger `set_updated_at` (helper `init.sql`).
+
+RLS forcée (miroir `users`/`producers`) :
+- SELECT/INSERT/UPDATE : `auth.uid() = user_id`
+- DELETE : refusé côté client (soft delete via job RGPD)
+
+## API / Endpoints
+
+Référence : ARCHITECTURE.md §3.
+
+| Endpoint | Input (Zod) | Output | Codes |
+|---|---|---|---|
+| `GET /api/v1/me/buyer-profile` | — | `{ profile \| null }` | 200 / 401 |
+| `PUT /api/v1/me/buyer-profile` | `BuyerProfileInput { displayName, addressLabel, city, postcode, latitude, longitude }` | `{ profile }` | 200 / 400 / 401 |
+
+Upsert unique (PUT) couvre KAN-81 (création onboarding) et KAN-82 (édition
+paramètres). Coordonnées fournies par la suggestion Adresse Gouv.fr retenue.
+
+## Impact state machine / events
+
+Référence : ARCHITECTURE.md §6 et §8.
+
+Aucun. La zone alimente le matching (§7) en lecture seule ; pas de transition mission.
+
+## Dépendances
+
+Référence : ARCHITECTURE.md §2. Provisionnement : `tech/setup.md`.
+
+- API Adresse Gouv.fr — `tech/setup.md` § APIs externes › API Adresse Gouv.fr
+  (statut « Fait », publique sans clé). Déjà consommée par `address-autocomplete.tsx`.
+- Supabase Postgres + PostGIS — `tech/setup.md` § Backend / Données (PostGIS déjà activé, premier usage KAN-17).
+- Aucun job Inngest.
+
+## État UI
+
+Référence : DESIGN.md + maquettes AC-02 / AC-11.
+
+- **AC-02 étape 1** : stepper 1/3, H1 Lora « Où vivez-vous ? », sous-titre,
+  carte blanche avec label « Adresse de livraison » + `AddressAutocomplete`,
+  suggestions Adresse Gouv.fr, help-text confidentialité, CTA « Continuer »,
+  lien « Passer ». (+ champ nom à confirmer.)
+- **AC-11** : section « Adresses de livraison » — KAN-25 n'affiche/édite que la
+  zone principale (création/modif). Multi-adresses hors US.
+- Responsive mobile + desktop obligatoire (DESIGN.md).
+
+## Risques techniques
+
+Références : ARCHITECTURE.md §9, §11, §13.
+
+- **Précision géocodage** : Adresse Gouv.fr renvoie un point ; suffisant pour le
+  buffer 10 km du matching. Pas de validation d'existence stricte côté serveur.
+- **Zone facultative au signup (« Passer »)** : un acheteur sans zone n'apparaît
+  dans aucun matching. Acceptable ; à signaler en UI plus tard.
+- **Confidentialité** : `location` est une donnée personnelle (RGPD) ; révélée au
+  rameneur seulement après confirmation mission (logique métier en aval, hors US).
+- **Free-tier** : pas d'appel serveur à Adresse Gouv.fr (autocomplete client) →
+  pas de quota consommé côté backend.
+
+## Tests envisagés
+
+Référence : ARCHITECTURE.md §10.
+
+- Unitaire `packages/contracts` : `BuyerProfileInput` (lat/lng bornés, champs requis).
+- Unitaire `packages/core` : normalisation zone, règle zone obligatoire matching.
+- Intégration `packages/db` : upsert `buyer_profiles` + RLS self (Supabase local), `ST_DWithin` sur point.
+- E2E web (Playwright) : onboarding → saisie zone via autocomplete → persistance ; édition zone depuis paramètres.

--- a/specs/KAN-25/proposal.md
+++ b/specs/KAN-25/proposal.md
@@ -1,0 +1,52 @@
+# Cadrage — KAN-25 Onboarding & zone
+
+## Liens
+
+- Jira : https://erkulaws.atlassian.net/browse/KAN-25
+- Epic : KAN-6 Profil Acheteur
+- Maquette : design/maquettes/acheteur/ac-02-onboarding.html (étape 1), design/maquettes/acheteur/ac-11-profil.html
+- PRD : §10 sitemap acheteur (AC-02 Onboarding, AC-11 Profil + paramètres) — PRD local non versionné
+- ARCHITECTURE : §5 (DB + RLS), §7 (matching géo, buffer 10 km), §3 (API), §10 (tests)
+
+## Pourquoi (côté tech)
+
+Après création de compte (KAN-2) et choix du rôle acheteur (AU-06), l'acheteur
+doit déclarer sa zone d'habitation. Cette zone est le point géographique qui
+alimente le pipeline de matching (ARCHITECTURE §7.2 étape 3 :
+`ST_DWithin(buyer_address, route_geom, 10000)`) — sans elle, aucune opportunité
+ne peut être proposée à un rameneur côté destination. KAN-25 pose le profil
+acheteur minimal (nom + zone), sa capture à l'onboarding (KAN-81) et son
+édition depuis les paramètres (KAN-82).
+
+## Périmètre technique
+
+**In scope :**
+
+- Étape 1 du wizard onboarding acheteur AC-02 « Où vivez-vous ? » : saisie zone
+  via autocomplete API Adresse Gouv.fr, persistance d'un point géographique.
+- Profil acheteur minimal : nom d'affichage + zone d'habitation (adresse label +
+  ville + code postal + `geography(Point)`).
+- Édition de la zone depuis les paramètres (AC-11, KAN-82).
+- Réutilisation / promotion du composant `address-autocomplete.tsx`
+  (`producer/` → `forms/`) en composant partagé.
+
+**Out of scope (cette US) :**
+
+- Étape 2 catégories (KAN-26) et étape 3 notifications (KAN-14) du wizard AC-02.
+- Gestion de plusieurs adresses (max 3, labels, codes porte) visible sur AC-11 :
+  KAN-25 ne gère qu'une zone principale unique. Multi-adresses → ticket dédié.
+- Wishlist, préférences catégories, paramètres notifications.
+- Onboarding rameneur (KAN-37) et producteur (KAN-16).
+
+## Hypothèses
+
+- **Nom à l'onboarding (à valider)** : KAN-81 mentionne « nom + zone » mais la
+  maquette AC-02 étape 1 n'affiche que le champ adresse. Hypothèse retenue :
+  on ajoute un champ « nom » à l'étape 1 (ou un sous-écran), à confirmer avec
+  le produit — conflit maquette ↔ subtask à arbitrer.
+- La zone est obligatoire pour finaliser l'onboarding acheteur, mais le bouton
+  « Passer » de la maquette permet de différer (zone null tant que non saisie ;
+  pas de matching tant qu'absente).
+- Un compte multi-rôle a 0 ou 1 profil acheteur (`buyer_profiles.user_id` UNIQUE),
+  miroir du pattern `producers` (KAN-16).
+- Stockage géo en `geography(Point, 4326)`, index GIST, cohérent avec §7.

--- a/specs/KAN-25/tasks.md
+++ b/specs/KAN-25/tasks.md
@@ -1,0 +1,21 @@
+# Tâches techniques internes — KAN-25 Onboarding & zone
+
+> Ces tâches ne sont pas dans Jira. Setup, migrations, refacto, helpers partagés.
+>
+> Subtasks Jira existantes (rappel — ne pas dupliquer ici) :
+> - KAN-81 — Renseigner son nom et sa zone d'habitation lors de l'onboarding
+> - KAN-82 — Modifier sa zone d'habitation depuis les paramètres
+
+## Tâches
+
+- [ ] Migration `supabase/migrations/<ts>_create_buyer_profiles.sql` : table + index GIST + trigger updated_at + RLS forcée (idempotente, rollback documenté).
+- [ ] Miroir RLS dans `supabase/policies/buyer_profiles.sql`.
+- [ ] Régénérer `packages/db/src/types.ts` (types Supabase) après migration.
+- [ ] Promouvoir `apps/web/components/producer/address-autocomplete.tsx` → `apps/web/components/forms/address-autocomplete.tsx` (ou `packages/ui-web`) et mettre à jour l'import côté producteur (KAN-17).
+- [ ] Helper PostGIS d'upsert point dans `packages/db` (`ST_SetSRID(ST_MakePoint(lng,lat),4326)`).
+- [ ] Schéma `BuyerProfileInput` dans `packages/contracts`.
+- [ ] Remplacer le stub `/onboarding/[role]` pour `acheteur` par le vrai écran (cf. specs/KAN-2/tasks.md).
+
+## Checklist pre-merge
+
+Voir ARCHITECTURE.md §14.3 — ne pas dupliquer ici.


### PR DESCRIPTION
## Cadrage technique KAN-25 — Onboarding & zone

Cadrage de la feature acheteur **KAN-25** (épic KAN-6 Profil Acheteur) : capture de la zone d'habitation à l'onboarding (KAN-81) et son édition depuis les paramètres (KAN-82).

Trois specs courtes dans `specs/KAN-25/` :
- `proposal.md` — périmètre, hypothèses
- `design.md` — table `buyer_profiles` (geography Point, GIST, RLS self), endpoints `me/buyer-profile`, réutilisation `AddressAutocomplete`
- `tasks.md` — tâches techniques internes (migration, promotion composant, types)

### Points à arbitrer (signalés dans les specs)
- **Nom à l'onboarding** : KAN-81 dit « nom + zone » mais la maquette AC-02 étape 1 n'affiche que le champ adresse → conflit maquette ↔ subtask à trancher.
- **Mono-adresse vs multi-adresses** : AC-11 montre jusqu'à 3 adresses ; KAN-25 est scopé sur une zone principale unique, multi-adresses renvoyé hors US.

### Mapping
`produit/jira_mapping.md` synchronisé (AC-02, AC-11, catalogue KAN-6, vue d'ensemble). Jira : commentaire + description pointant vers les specs (pas de transition — `Ideas → À faire` au merge).

https://claude.ai/code/session_01N4uurq95Uh4okse6XnhSPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4uurq95Uh4okse6XnhSPN)_