### PR TITLE
specs KAN-26 — Préférences catégories

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -42,7 +42,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | Écran | Maquette | Ticket(s) Jira principal(aux) | Tickets liés |
 |-------|----------|-------------------------------|--------------|
 | AC-01 Inscription / connexion | `ac-01-authentication.html` | KAN-2 (Création de compte), KAN-3 (Connexion), KAN-157 (Récup. mot de passe) | [Cadrage KAN-2](specs/KAN-2/), [Cadrage KAN-3](specs/KAN-3/), [Cadrage KAN-157](specs/KAN-157/) |
-| AC-02 Onboarding | `ac-02-onboarding.html` | KAN-25 (Onboarding & zone), KAN-26 (Préférences catégories) | [Cadrage KAN-25](specs/KAN-25/) |
+| AC-02 Onboarding | `ac-02-onboarding.html` | KAN-25 (Onboarding & zone), KAN-26 (Préférences catégories) | [Cadrage KAN-25](specs/KAN-25/), [Cadrage KAN-26](specs/KAN-26/) |
 | AC-03 Accueil | `ac-03-accueil.html` | KAN-28 (Catalogue filtré) | — |
 | AC-04 Catalogue parcourable | `ac-04-catalogue.html` | KAN-28 (Catalogue filtré) | KAN-29 (Zone non couverte) |
 | AC-05 Fiche produit | `ac-05-fiche-produit.html` | KAN-28 (Catalogue filtré) | KAN-30 (Wishlist privée) |
@@ -54,7 +54,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | AC-08bis Profil public producteur | `ac-08bis-profil-producteur.html` | KAN-53 (Profils publics & avis) | — |
 | AC-09 Historique commandes | `ac-09-historique.html` | KAN-27 (Historique commandes) | KAN-36 (Factures PDF) |
 | AC-10 Évaluation post-livraison | `ac-10-evaluation.html` | KAN-52 (Notation post-livraison) | — |
-| AC-11 Profil + paramètres | `ac-11-profil.html` | KAN-26 (Préférences catégories), KAN-25 (Onboarding & zone) | [Cadrage KAN-25](specs/KAN-25/) |
+| AC-11 Profil + paramètres | `ac-11-profil.html` | KAN-26 (Préférences catégories), KAN-25 (Onboarding & zone) | [Cadrage KAN-25](specs/KAN-25/), [Cadrage KAN-26](specs/KAN-26/) |
 | AC-12 Zone non couverte | `ac-12-zone-non-couverte.html` | KAN-29 (Zone non couverte & liste d'attente) | — |
 
 ### Parcours Rameneur (§10.4 PRD)
@@ -129,7 +129,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 |--------|------|--------|--------|
 | KAN-6 | Epic | Ideas | Profil Acheteur |
 | KAN-25 | Feature | Examiner | Onboarding & zone — [Cadrage tech](specs/KAN-25/) — mergé sur main (PR #53) |
-| KAN-26 | Feature | Ideas | Préférences catégories |
+| KAN-26 | Feature | Ideas | Préférences catégories — [Cadrage tech](specs/KAN-26/) |
 | KAN-27 | Feature | Ideas | Historique commandes |
 
 ### KAN-7 — Wishlist & Matching

--- a/specs/KAN-26/design.md
+++ b/specs/KAN-26/design.md
@@ -1,0 +1,110 @@
+# Conception technique — KAN-26 Préférences catégories
+
+## Vue d'ensemble
+
+Extension du profil acheteur de KAN-25 : on ajoute une colonne tableau
+`preferred_categories product_category[]` à `buyer_profiles` et on la propage à
+travers les couches déjà en place (contrats → core → repo → wizard onboarding +
+paramètres). Aucune nouvelle table, aucune nouvelle RLS (les policies self de
+`buyer_profiles` couvrent la colonne). Le mouvement principal est côté
+`apps/web` (étape 2 du wizard `/onboarding/acheteur` + sous-écran préférences
+dans `/acheteur/profil`) avec une grille de chips multi-select calquée sur le
+pattern existant (labels producteur / KAN-24). La liste de catégories vient de
+`PRODUCT_CATEGORIES` — pas de duplication.
+
+## Packages touchés
+
+- [x] `packages/contracts` — `buyer-profile` : ajout `preferredCategories: z.array(ProductCategory).max(8)` dans `BuyerProfileUpsertInput` + `BuyerProfileSnapshot` (réutilise `ProductCategory` de `product/shared.ts`)
+- [x] `packages/core` — `buyer-profile` : propagation `preferredCategories` dans le use case upsert + adapters (dédoublonnage, validation whitelist)
+- [x] `packages/db` — `buyerProfilesRepo` : `preferred_categories` ajouté à `SELECT_COLUMNS` + mapping `create`/`update` (déjà générique via `BuyerProfileUpdate`) ; `types.ts` mis à jour
+- [x] `apps/web` — étape 2 wizard `/onboarding/acheteur` + section/sous-écran préférences dans `/acheteur/profil` + extension du route handler `PUT /api/v1/me/buyer-profile`
+- [ ] `apps/mobile` — différé (non scaffoldé)
+- [ ] `packages/jobs` — non applicable (aucun event)
+- [x] `supabase/migrations` — `ALTER TABLE buyer_profiles ADD COLUMN preferred_categories product_category[] NOT NULL DEFAULT '{}'`
+- [ ] `supabase/policies` — aucun changement (policies self existantes suffisent)
+- [x] `packages/ui-web` — composant chips multi-select catégories (réutilisable onboarding + paramètres), ou réutilisation du pattern chips existant
+
+## Modèle de données
+
+Référence : ARCHITECTURE.md §5.
+
+Table `public.buyer_profiles` (KAN-25), ajout d'une colonne :
+
+- `preferred_categories` (`product_category[]`, NOT NULL, DEFAULT `'{}'`) —
+  sous-ensemble de l'enum `product_category` (KAN-20). Vide = aucune préférence.
+
+Pas d'index (lecture ponctuelle par `user_id`, jamais filtrée en masse au MVP).
+Type enum déjà existant (`product_category`) — aucun `CREATE TYPE`. RLS
+inchangée : les policies `buyer_profiles_{select,insert,update}_self` couvrent
+la nouvelle colonne. Rollback : `ALTER TABLE buyer_profiles DROP COLUMN preferred_categories`.
+
+## API / Endpoints
+
+Référence : ARCHITECTURE.md §3.
+
+Extension de l'endpoint KAN-25 (pas de nouvelle route) :
+
+| Endpoint | Input (Zod) | Output | Codes |
+|---|---|---|---|
+| `GET /api/v1/me/buyer-profile` | — | `{ profile \| null }` (inclut `preferredCategories`) | 200 / 401 |
+| `PUT /api/v1/me/buyer-profile` | `BuyerProfileUpsertInput { …, preferredCategories: ProductCategory[] }` | `{ profile }` | 200 / 400 / 401 |
+
+`preferredCategories` optionnel à l'input (rétro-compat KAN-25) : absent =
+inchangé, `[]` = réinitialisé. Valeurs hors whitelist `product_category` →
+400 (Zod). Couvre KAN-83 (onboarding) et KAN-84 (paramètres) via le même upsert.
+
+## Impact state machine / events
+
+Référence : ARCHITECTURE.md §6 et §8.
+
+Aucun. Pas de transition mission, pas d'event Inngest, pas d'impact matching (§7).
+
+## Dépendances
+
+Référence : ARCHITECTURE.md §2. Provisionnement : `tech/setup.md`.
+
+- Aucun service externe. Pas de mise à jour `tech/setup.md`.
+- Internes : `buyer_profiles` + repo/contrats/core `buyer-profile` (KAN-25) ;
+  enum `product_category` + `PRODUCT_CATEGORIES`/`PRODUCT_CATEGORY_FR`/
+  `PRODUCT_CATEGORY_EMOJI` (KAN-20/24) ; pattern chips multi-select (KAN-24).
+
+## État UI
+
+Référence : DESIGN.md + maquettes AC-02 (étape 2) / AC-11.
+
+- **AC-02 étape 2** : stepper 2/3, H1 Lora « Qu'est-ce qui vous tente ? »,
+  sous-titre, grille de `cat-chip` (2 colonnes) avec emoji + libellé + check,
+  multi-select, help-text « secs / non sensibles uniquement », CTA « Continuer »,
+  « Retour », lien « Passer ». Chips pilotés par `PRODUCT_CATEGORIES` (libellés
+  FR + emoji du contrat), **pas** la liste en dur de la maquette (cf. hypothèse
+  conflit taxonomie → `notes.md`).
+- **AC-11** : la ligne « Catégories d'intérêt » (sous « Préférences ») ouvre un
+  sous-écran / section d'édition réutilisant la même grille de chips ;
+  sous-titre = résumé des catégories choisies.
+- Responsive mobile + desktop obligatoire (DESIGN.md).
+
+## Risques techniques
+
+Références : ARCHITECTURE.md §9, §11, §13.
+
+- **Divergence taxonomie maquette ↔ enum produit** : risque principal. La
+  maquette propose des catégories absentes de `product_category` (laitages,
+  œufs). Aligner sur l'enum (décision tech) et faire arbitrer le libellé produit ;
+  consigner dans `notes.md`. Ne pas inventer de second enum côté acheteur.
+- **Évolution de l'enum** : si `product_category` gagne une valeur (`ALTER TYPE`),
+  les préférences en bénéficient automatiquement (tableau du même type) — pas de
+  migration de données.
+- **Free-tier** : aucun appel externe, coût nul.
+
+## Tests envisagés
+
+Référence : ARCHITECTURE.md §10.
+
+- Unitaire `packages/contracts` : `BuyerProfileUpsertInput.preferredCategories`
+  (valeur whitelistée acceptée, hors whitelist refusée, `> 8` refusé, `[]` et
+  absent acceptés, doublons normalisés).
+- Unitaire `packages/core` : propagation + dédoublonnage des préférences.
+- Intégration `packages/db` : upsert `preferred_categories` + RLS self (Supabase local).
+- E2E web (Playwright) : onboarding étape 2 → sélection chips → persistance ;
+  édition depuis `/acheteur/profil` (déféré si fixtures auth acheteur indisponibles,
+  cohérent KAN-25).

--- a/specs/KAN-26/proposal.md
+++ b/specs/KAN-26/proposal.md
@@ -1,0 +1,64 @@
+# Cadrage — KAN-26 Préférences catégories
+
+## Liens
+
+- Jira : https://erkulaws.atlassian.net/browse/KAN-26
+- Epic : KAN-6 Profil Acheteur
+- Maquette : design/maquettes/acheteur/ac-02-onboarding.html (étape 2), design/maquettes/acheteur/ac-11-profil.html (ligne « Catégories d'intérêt »)
+- PRD : §10 sitemap acheteur (AC-02 Onboarding étape 2, AC-11 Profil + paramètres) — PRD local non versionné
+- ARCHITECTURE : §5 (DB + RLS), §3 (API), §7 (matching — sans impact), §10 (tests)
+
+## Pourquoi (côté tech)
+
+KAN-25 a posé le profil acheteur (`buyer_profiles`), l'étape 1 du wizard
+`/onboarding/acheteur` (zone) et la page paramètres `/acheteur/profil`. KAN-26
+ajoute la **2ᵉ étape** de ce même wizard (AC-02 « Qu'est-ce qui vous tente ? »)
+et la **ligne « Catégories d'intérêt »** des paramètres (AC-11) : l'acheteur
+sélectionne un sous-ensemble de catégories produit qui personnalise son accueil
+(tri / mise en avant côté AC-03, livré par KAN-28). C'est une préférence de
+confort, pas un filtre dur ni un gate d'onboarding. Aucun impact sur le pipeline
+de matching (§7), piloté par la wishlist et la zone, pas par les préférences.
+
+La liste de catégories est déjà la source de vérité produit :
+`PRODUCT_CATEGORIES` (`packages/contracts/src/product/shared.ts`, 8 valeurs +
+`PRODUCT_CATEGORY_FR` + `PRODUCT_CATEGORY_EMOJI`), miroir de l'enum Postgres
+`product_category` (KAN-20). On la réutilise telle quelle — pas de taxonomie
+acheteur parallèle.
+
+## Périmètre technique
+
+**In scope :**
+
+- Étape 2 du wizard onboarding acheteur AC-02 « Qu'est-ce qui vous tente ? » :
+  grille de chips multi-select alimentée par `PRODUCT_CATEGORIES`, persistance
+  d'un `product_category[]` sur `buyer_profiles` (KAN-83).
+- Édition des préférences depuis les paramètres (AC-11, ligne « Catégories
+  d'intérêt » → sous-écran ou section dédiée) (KAN-84).
+- Extension du contrat / use case / repo `buyer-profile` existants (KAN-25)
+  pour porter le champ `preferredCategories`.
+
+**Out of scope (cette US) :**
+
+- Étape 1 zone (KAN-25, livré) et étape 3 notifications (KAN-14) du wizard AC-02.
+- Exploitation des préférences pour trier/filtrer l'accueil (KAN-28 Catalogue filtré).
+- Wishlist (KAN-30) et matching (KAN-7) — préférences ≠ envies.
+- Toute nouvelle catégorie produit (gérée par l'enum `product_category`, KAN-20/24).
+
+## Hypothèses
+
+- **Conflit maquette ↔ enum produit (à arbitrer produit)** : la maquette AC-02
+  étape 2 liste 8 chips d'une taxonomie distincte (« Produits laitiers secs »,
+  « Œufs », « Légumes robustes », « Légumineuses »…) qui ne mappe pas 1:1 sur
+  les 8 `product_category` réels (miel_et_ruche, fruits, legumes,
+  cereales_legumineuses, conserves_confitures, pain_biscuits, huiles,
+  boissons_non_alcoolisees). Hypothèse retenue : **on aligne les préférences sur
+  l'enum `product_category`** (sinon le tri/filtrage AC-03 est impossible), et on
+  consigne l'écart dans `specs/KAN-26/notes.md` à l'implémentation pour arbitrage.
+- **Sélection facultative** : 0 catégorie autorisé (`preferred_categories = '{}'`),
+  bouton « Passer » de la maquette honoré. Pas de gate d'onboarding.
+- **Personnalisation seule** : les préférences influencent l'affichage (KAN-28),
+  jamais la visibilité réelle du catalogue (« vous pourrez tout voir »).
+- **Réutilisation de l'endpoint KAN-25** : `PUT /api/v1/me/buyer-profile` (upsert)
+  est étendu avec `preferredCategories` plutôt que de créer une route dédiée — le
+  profil existe déjà (créé à l'étape 1). À confirmer si l'on préfère un endpoint
+  granulaire `PUT …/buyer-profile/categories`.

--- a/specs/KAN-26/tasks.md
+++ b/specs/KAN-26/tasks.md
@@ -1,0 +1,22 @@
+# Tâches techniques internes — KAN-26 Préférences catégories
+
+> Ces tâches ne sont pas dans Jira. Setup, migrations, refacto, helpers partagés.
+>
+> Subtasks Jira existantes (rappel — ne pas dupliquer ici) :
+> - KAN-83 — Indiquer ses préférences de catégories de produits lors de l'onboarding
+> - KAN-84 — Modifier ses préférences de catégories depuis les paramètres
+
+## Tâches
+
+- [ ] Migration `supabase/migrations/<ts>_buyer_profiles_preferred_categories.sql` : `ADD COLUMN preferred_categories product_category[] NOT NULL DEFAULT '{}'` + `COMMENT ON COLUMN` (idempotence `ADD COLUMN IF NOT EXISTS`, rollback documenté `DROP COLUMN`).
+- [ ] Déclarer `preferred_categories` sur `buyer_profiles` dans `packages/db/src/types.ts` (Row/Insert/Update, types maintenus à la main) et l'ajouter à `SELECT_COLUMNS` du repo.
+- [ ] Étendre `BuyerProfileUpsertInput` + `BuyerProfileSnapshot` (`packages/contracts/buyer-profile`) avec `preferredCategories` (réutiliser `ProductCategory`, `.max(8)`, optionnel).
+- [ ] Propager `preferredCategories` dans le use case upsert + adapters `packages/core/buyer-profile` (dédoublonnage).
+- [ ] Étendre le route handler `PUT /api/v1/me/buyer-profile` (champ optionnel, rétro-compat KAN-25).
+- [ ] Composant chips multi-select catégories réutilisable (onboarding + paramètres), alimenté par `PRODUCT_CATEGORIES` / `PRODUCT_CATEGORY_FR` / `PRODUCT_CATEGORY_EMOJI`.
+- [ ] Étape 2 du wizard `/onboarding/acheteur` (intégration au stepper KAN-25) + section/sous-écran préférences dans `/acheteur/profil`.
+- [ ] `specs/KAN-26/notes.md` : consigner la déviation taxonomie maquette AC-02 ↔ enum `product_category` (arbitrage produit).
+
+## Checklist pre-merge
+
+Voir ARCHITECTURE.md §14.3 — ne pas dupliquer ici.


### PR DESCRIPTION
Cadrage technique de **KAN-26 — Préférences catégories** (epic KAN-6 Profil Acheteur).

Trois specs courtes dans `specs/KAN-26/` :
- `proposal.md` — périmètre, hypothèses
- `design.md` — conception technique (DB, API, UI, tests)
- `tasks.md` — tâches techniques internes

## Résumé

KAN-26 ajoute la **2ᵉ étape du wizard `/onboarding/acheteur`** (catégories, AC-02) et la **ligne « Catégories d'intérêt » des paramètres** (AC-11), en extension directe du profil acheteur posé par KAN-25. L'acheteur sélectionne un sous-ensemble des `product_category` existants (enum KAN-20) ; nouvelle colonne `preferred_categories product_category[]` sur `buyer_profiles`, endpoint `PUT /api/v1/me/buyer-profile` étendu. Personnalisation seule (pas de filtre dur, pas d'impact matching).

## Points à arbitrer

- **Conflit taxonomie maquette ↔ enum produit** : la maquette AC-02 affiche des catégories (laitages, œufs…) absentes de `product_category`. Hypothèse retenue : aligner sur l'enum produit, écart consigné dans `notes.md` à l'implémentation.
- Endpoint étendu (KAN-25) vs route dédiée `…/categories` — recommandation : étendre l'existant.

Subtasks Jira : KAN-83 (onboarding), KAN-84 (paramètres).

🔗 https://erkulaws.atlassian.net/browse/KAN-26

https://claude.ai/code/session_013GDE2dr3884ngeYFqKJp48

---
_Generated by [Claude Code](https://claude.ai/code/session_013GDE2dr3884ngeYFqKJp48)_