### PR TITLE
[KAN-26] Préférences catégories acheteur

### DIFF
--- a/apps/web/app/(auth)/onboarding/acheteur/acheteur-client.tsx
+++ b/apps/web/app/(auth)/onboarding/acheteur/acheteur-client.tsx
@@ -1,23 +1,28 @@
 "use client"
 
 import { type BuyerProfileSnapshot } from "@delta/contracts/buyer-profile"
-import { OnboardingWizardShell } from "@delta/ui-web"
+import { OnboardingWizardShell, type WizardStep } from "@delta/ui-web"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
+import { useState } from "react"
 
+import { BuyerCategoriesForm } from "@/components/buyer/buyer-categories-form"
 import { BuyerZoneForm } from "@/components/buyer/buyer-zone-form"
 
 /**
- * Onboarding acheteur (KAN-25, AC-02 étape 1). Une seule étape au MVP : la
- * zone d'habitation. Les étapes catégories (KAN-26) et notifications (KAN-14)
- * de la maquette sont hors périmètre de cette US.
+ * Onboarding acheteur (KAN-25 + KAN-26, AC-02). Deux étapes au MVP :
+ *   1. Zone d'habitation (KAN-25)
+ *   2. Préférences catégories (KAN-26)
  *
- * Atterrissage post-onboarding : `/acheteur/profil` (page paramètres livrée
- * par KAN-82), en attendant l'accueil acheteur AC-03 (KAN-28). Cf.
- * specs/KAN-25/notes.md.
+ * L'étape 3 notifications de la maquette relève de KAN-14 (hors périmètre).
+ *
+ * Atterrissage post-onboarding : `/acheteur/profil` (page paramètres), en
+ * attendant l'accueil acheteur AC-03 (KAN-28). Cf. specs/KAN-25/notes.md.
  */
 
 const HOME_AFTER_ONBOARDING = "/acheteur/profil"
+
+type Step = "zone" | "categories"
 
 export function BuyerOnboardingClient({
   initial,
@@ -25,46 +30,112 @@ export function BuyerOnboardingClient({
   initial: BuyerProfileSnapshot | null
 }) {
   const router = useRouter()
+  const [step, setStep] = useState<Step>("zone")
+  const [snapshot, setSnapshot] = useState<BuyerProfileSnapshot | null>(initial)
 
-  function handleSaved() {
+  function handleZoneSaved(updated: BuyerProfileSnapshot) {
+    setSnapshot(updated)
+    setStep("categories")
+  }
+
+  function handleCategoriesSaved() {
     router.push(HOME_AFTER_ONBOARDING)
   }
+
+  const steps: WizardStep[] = [
+    {
+      id: "zone",
+      title: "Votre zone",
+      meta: "Adresse de livraison",
+      status: step === "zone" ? "current" : "done",
+    },
+    {
+      id: "categories",
+      title: "Vos envies",
+      meta: "Catégories d'intérêt",
+      status: step === "categories" ? "current" : "pending",
+    },
+  ]
+
+  const heading = step === "zone" ? "Où vivez-vous ?" : "Qu'est-ce qui vous tente ?"
+  const subheading =
+    step === "zone"
+      ? "Nous afficherons les produits que des rameneurs peuvent ramener jusqu'à votre quartier. Vous pourrez ajouter une autre adresse plus tard."
+      : "Choisissez les catégories qui vous intéressent. Cela personnalise votre accueil — vous pourrez tout voir dans le catalogue."
 
   return (
     <OnboardingWizardShell
       roleLabel="Espace acheteur"
-      heading="Où vivez-vous ?"
-      subheading="Nous afficherons les produits que des rameneurs peuvent ramener jusqu'à votre quartier. Vous pourrez ajouter une autre adresse plus tard."
-      steps={[
-        {
-          id: "zone",
-          title: "Votre zone",
-          meta: "Adresse de livraison",
-          status: "current",
-        },
-      ]}
+      heading={heading}
+      subheading={subheading}
+      steps={steps}
     >
-      <header className="flex flex-col gap-2">
-        <p className="font-body text-xs font-bold uppercase tracking-[0.04em] text-cream-600">
-          Étape 1
-        </p>
-        <h2 className="font-display text-3xl font-semibold leading-tight tracking-tight text-green-900">
-          Où vivez-vous ?
-        </h2>
-        <p className="font-body text-md leading-relaxed text-cream-700">
-          Indiquez votre adresse pour voir les produits livrables dans votre
-          quartier.
-        </p>
-      </header>
+      {step === "zone" ? (
+        <>
+          <header className="flex flex-col gap-2">
+            <p className="font-body text-xs font-bold uppercase tracking-[0.04em] text-cream-600">
+              Étape 1 sur 2
+            </p>
+            <h2 className="font-display text-3xl font-semibold leading-tight tracking-tight text-green-900">
+              Où vivez-vous ?
+            </h2>
+            <p className="font-body text-md leading-relaxed text-cream-700">
+              Indiquez votre adresse pour voir les produits livrables dans votre
+              quartier.
+            </p>
+          </header>
 
-      <BuyerZoneForm initial={initial} mode="onboarding" onSaved={handleSaved} />
+          <BuyerZoneForm
+            initial={snapshot}
+            mode="onboarding"
+            onSaved={handleZoneSaved}
+          />
 
-      <Link
-        href={HOME_AFTER_ONBOARDING}
-        className="font-body text-sm text-cream-600 hover:text-cream-950"
-      >
-        Passer pour l&apos;instant
-      </Link>
+          <Link
+            href={HOME_AFTER_ONBOARDING}
+            className="font-body text-sm text-cream-600 hover:text-cream-950"
+          >
+            Passer pour l&apos;instant
+          </Link>
+        </>
+      ) : (
+        <>
+          <header className="flex flex-col gap-2">
+            <p className="font-body text-xs font-bold uppercase tracking-[0.04em] text-cream-600">
+              Étape 2 sur 2
+            </p>
+            <h2 className="font-display text-3xl font-semibold leading-tight tracking-tight text-green-900">
+              Qu&apos;est-ce qui vous tente ?
+            </h2>
+            <p className="font-body text-md leading-relaxed text-cream-700">
+              Choisissez les catégories qui vous intéressent. Cela personnalise
+              votre accueil — vous pourrez tout voir dans le catalogue.
+            </p>
+          </header>
+
+          <BuyerCategoriesForm
+            initial={snapshot}
+            mode="onboarding"
+            onSaved={handleCategoriesSaved}
+          />
+
+          <div className="flex items-center gap-4">
+            <button
+              type="button"
+              onClick={() => setStep("zone")}
+              className="font-body text-sm text-cream-600 hover:text-cream-950"
+            >
+              ← Retour
+            </button>
+            <Link
+              href={HOME_AFTER_ONBOARDING}
+              className="font-body text-sm text-cream-600 hover:text-cream-950"
+            >
+              Passer pour l&apos;instant
+            </Link>
+          </div>
+        </>
+      )}
     </OnboardingWizardShell>
   )
 }

--- a/apps/web/app/(auth)/onboarding/acheteur/page.tsx
+++ b/apps/web/app/(auth)/onboarding/acheteur/page.tsx
@@ -44,6 +44,7 @@ export default async function BuyerOnboardingPage() {
               city: profile.city,
               postcode: profile.postcode,
               has_location: false,
+              preferred_categories: profile.preferred_categories,
             }
           : null
       }

--- a/apps/web/app/acheteur/profil/page.tsx
+++ b/apps/web/app/acheteur/profil/page.tsx
@@ -1,8 +1,10 @@
+import { type BuyerProfileSnapshot } from "@delta/contracts/buyer-profile"
 import { buyerProfilesRepo } from "@delta/db"
 import { usersRepo } from "@delta/db/users"
 import Link from "next/link"
 import { redirect } from "next/navigation"
 
+import { BuyerCategoriesForm } from "@/components/buyer/buyer-categories-form"
 import { BuyerZoneForm } from "@/components/buyer/buyer-zone-form"
 import { getServerSupabase } from "@/lib/supabase/server"
 
@@ -35,6 +37,16 @@ export default async function BuyerZoneSettingsPage() {
   }
 
   const profile = await buyerProfilesRepo.findByUserId(supabase, user.id)
+  const snapshot: BuyerProfileSnapshot | null = profile
+    ? {
+        display_name: profile.display_name,
+        address_label: profile.address_label,
+        city: profile.city,
+        postcode: profile.postcode,
+        has_location: false,
+        preferred_categories: profile.preferred_categories,
+      }
+    : null
 
   return (
     <main className="min-h-screen bg-cream-50 px-6 py-10">
@@ -44,29 +56,32 @@ export default async function BuyerZoneSettingsPage() {
             Paramètres
           </p>
           <h1 className="font-display text-3xl font-semibold leading-tight tracking-tight text-green-900">
-            Ma zone d&apos;habitation
+            Mon profil acheteur
           </h1>
           <p className="font-body text-md leading-relaxed text-cream-700">
-            Cette adresse détermine les produits que des rameneurs peuvent vous
-            livrer. Vous pouvez la modifier à tout moment.
+            Votre zone détermine les produits que des rameneurs peuvent vous
+            livrer ; vos catégories d&apos;intérêt personnalisent votre accueil.
+            Vous pouvez tout modifier à tout moment.
           </p>
         </header>
 
-        <section className="rounded-2xl border border-cream-200 bg-white p-6 shadow-sm">
-          <BuyerZoneForm
-            initial={
-              profile
-                ? {
-                    display_name: profile.display_name,
-                    address_label: profile.address_label,
-                    city: profile.city,
-                    postcode: profile.postcode,
-                    has_location: false,
-                  }
-                : null
-            }
-            mode="edit"
-          />
+        <section className="flex flex-col gap-4 rounded-2xl border border-cream-200 bg-white p-6 shadow-sm">
+          <h2 className="font-display text-xl font-semibold text-green-900">
+            Ma zone d&apos;habitation
+          </h2>
+          <BuyerZoneForm initial={snapshot} mode="edit" />
+        </section>
+
+        <section className="flex flex-col gap-4 rounded-2xl border border-cream-200 bg-white p-6 shadow-sm">
+          <div className="flex flex-col gap-1">
+            <h2 className="font-display text-xl font-semibold text-green-900">
+              Mes catégories d&apos;intérêt
+            </h2>
+            <p className="font-body text-sm leading-relaxed text-cream-700">
+              Les produits de ces catégories sont mis en avant sur votre accueil.
+            </p>
+          </div>
+          <BuyerCategoriesForm initial={snapshot} mode="edit" />
         </section>
 
         <Link

--- a/apps/web/app/api/v1/me/buyer-profile/categories/route.ts
+++ b/apps/web/app/api/v1/me/buyer-profile/categories/route.ts
@@ -11,64 +11,21 @@ import {
 import { type NextRequest, NextResponse } from "next/server"
 
 import {
-  getBuyerProfileAdapter,
+  getBuyerCategoriesAdapter,
   getBuyerRoleChecker,
-  getGeocodeAdapter,
 } from "@/lib/buyer/adapters"
 import { serializeError } from "@/lib/serialize-error"
 import { getServerSupabase } from "@/lib/supabase/server"
 import { getRateLimitStore } from "@/lib/upstash"
 
 /**
- * GET /api/v1/me/buyer-profile (KAN-25).
+ * PUT /api/v1/me/buyer-profile/categories (KAN-26 — KAN-83 onboarding +
+ * KAN-84 paramètres).
  *
- * Renvoie le snapshot du profil acheteur du caller, ou `null` si aucune zone
- * n'a encore été enregistrée. Codes : 200 / 401 / 403
- */
-export async function GET() {
-  const supabase = await getServerSupabase()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) {
-    return NextResponse.json(
-      { error: "Non authentifié.", code: BUYER_PROFILE_ERROR_CODES.Unknown },
-      { status: 401 },
-    )
-  }
-
-  const role = getBuyerRoleChecker(supabase)
-  if (!(await role.hasBuyerRole(user.id))) {
-    return NextResponse.json(
-      {
-        error: "Rôle acheteur requis.",
-        code: BUYER_PROFILE_ERROR_CODES.RoleForbidden,
-      },
-      { status: 403 },
-    )
-  }
-
-  const profile = await getBuyerProfileAdapter(supabase).findByUserId(user.id)
-  if (!profile) {
-    return NextResponse.json(null, { status: 200 })
-  }
-
-  const snapshot: BuyerProfileSnapshot = {
-    display_name: profile.display_name,
-    address_label: profile.address_label,
-    city: profile.city,
-    postcode: profile.postcode,
-    has_location: profile.has_location,
-    preferred_categories: profile.preferred_categories,
-  }
-  return NextResponse.json(snapshot, { status: 200 })
-}
-
-/**
- * PUT /api/v1/me/buyer-profile (KAN-25 — KAN-81 onboarding + KAN-82 édition).
- *
- * Upsert de la zone d'habitation (+ nom facultatif). Le géocodage est
- * best-effort et ne bloque jamais l'écriture du texte.
+ * Upsert des préférences catégories de l'acheteur (sous-ensemble de l'enum
+ * product_category). Endpoint dédié pour ne pas toucher au contrat d'upsert
+ * de la zone (qui exige `address_label`) ni risquer de réinitialiser la
+ * position — cf. specs/KAN-26/notes.md.
  *
  * Codes : 200 / 400 / 401 / 403 / 429
  */
@@ -96,12 +53,15 @@ export async function PUT(req: NextRequest) {
   }
 
   try {
-    const updated = await coreBuyerProfile.upsertBuyerProfile(body, user.id, {
-      ...getBuyerProfileAdapter(supabase),
-      ...getBuyerRoleChecker(supabase),
-      ...getGeocodeAdapter(),
-      store: getRateLimitStore(),
-    })
+    const updated = await coreBuyerProfile.updateBuyerCategories(
+      body,
+      user.id,
+      {
+        ...getBuyerCategoriesAdapter(supabase),
+        ...getBuyerRoleChecker(supabase),
+        store: getRateLimitStore(),
+      },
+    )
     const snapshot: BuyerProfileSnapshot = {
       display_name: updated.display_name,
       address_label: updated.address_label,
@@ -138,7 +98,7 @@ export async function PUT(req: NextRequest) {
         { status: 400 },
       )
     }
-    console.error("[api/v1/me/buyer-profile] PUT failed", {
+    console.error("[api/v1/me/buyer-profile/categories] PUT failed", {
       userId: user.id,
       error: serializeError(err),
     })

--- a/apps/web/components/buyer/buyer-categories-form.tsx
+++ b/apps/web/components/buyer/buyer-categories-form.tsx
@@ -1,0 +1,173 @@
+"use client"
+
+import { type BuyerProfileSnapshot } from "@delta/contracts/buyer-profile"
+import {
+  PRODUCT_CATEGORIES,
+  PRODUCT_CATEGORY_EMOJI,
+  PRODUCT_CATEGORY_FR,
+  type ProductCategory,
+} from "@delta/contracts/product"
+import { useState, type FormEvent } from "react"
+
+/**
+ * BuyerCategoriesForm (KAN-26) — sélection des catégories d'intérêt de
+ * l'acheteur (AC-02 étape 2 « Qu'est-ce qui vous tente ? » + AC-11 ligne
+ * « Catégories d'intérêt »).
+ *
+ * Source : maquette `design/maquettes/acheteur/ac-02-onboarding.html` (étape 2).
+ * Les chips sont pilotés par l'enum `product_category` (libellés FR + emoji du
+ * contrat), pas par la liste en dur de la maquette — voir specs/KAN-26/notes.md
+ * (conflit de taxonomie maquette ↔ enum produit).
+ *
+ * Deux modes :
+ *   - `onboarding` : CTA « Continuer » (appelle `onSaved` après PUT réussi)
+ *   - `edit`       : CTA « Enregistrer » depuis les paramètres (KAN-84)
+ *
+ * La sélection vide est valide (« aucune préférence »).
+ */
+
+export type BuyerCategoriesFormProps = {
+  initial: BuyerProfileSnapshot | null
+  mode?: "onboarding" | "edit"
+  onSaved?: (updated: BuyerProfileSnapshot) => void
+}
+
+export function BuyerCategoriesForm({
+  initial,
+  mode = "onboarding",
+  onSaved,
+}: BuyerCategoriesFormProps) {
+  const [selected, setSelected] = useState<Set<ProductCategory>>(
+    () => new Set(initial?.preferred_categories ?? []),
+  )
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+
+  function toggle(cat: ProductCategory) {
+    setSaved(false)
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(cat)) next.delete(cat)
+      else next.add(cat)
+      return next
+    })
+  }
+
+  function handleSubmit(e: FormEvent) {
+    void submit(e)
+  }
+
+  async function submit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setSaved(false)
+    setSubmitting(true)
+    try {
+      const res = await fetch("/api/v1/me/buyer-profile/categories", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ preferred_categories: [...selected] }),
+      })
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as
+          | { error?: string }
+          | null
+        throw new Error(body?.error ?? "Enregistrement impossible, réessayez.")
+      }
+      const updated = (await res.json()) as BuyerProfileSnapshot
+      setSaved(true)
+      onSaved?.(updated)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Une erreur est survenue.")
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+      <div
+        className="grid grid-cols-1 gap-2.5 mobile:grid-cols-2"
+        role="group"
+        aria-label="Catégories d'intérêt"
+      >
+        {PRODUCT_CATEGORIES.map((cat) => {
+          const active = selected.has(cat)
+          return (
+            <button
+              type="button"
+              key={cat}
+              onClick={() => toggle(cat)}
+              aria-pressed={active}
+              className={`flex items-center gap-2.5 rounded-xl border-[1.5px] px-3 py-3.5 text-left transition-colors ${
+                active
+                  ? "border-green-600 bg-green-50"
+                  : "border-cream-200 bg-white hover:border-green-400 hover:bg-green-50"
+              }`}
+            >
+              <span
+                aria-hidden="true"
+                className={`grid h-9 w-9 shrink-0 place-items-center rounded-lg text-lg ${
+                  active ? "bg-green-100" : "bg-earth-100"
+                }`}
+              >
+                {PRODUCT_CATEGORY_EMOJI[cat]}
+              </span>
+              <span className="flex-1 font-body text-sm font-semibold text-cream-950">
+                {PRODUCT_CATEGORY_FR[cat]}
+              </span>
+              <span
+                aria-hidden="true"
+                className={`grid h-5 w-5 shrink-0 place-items-center rounded-full border-2 text-[11px] font-bold text-white ${
+                  active
+                    ? "border-green-600 bg-green-600"
+                    : "border-cream-300 bg-transparent"
+                }`}
+              >
+                {active ? "✓" : ""}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      <p className="font-body text-xs leading-relaxed text-cream-600">
+        Seuls les produits secs et agricoles non sensibles sont proposés au MVP
+        (pas de frais ni d&apos;alcool). Vous pourrez tout voir dans le
+        catalogue.
+      </p>
+
+      {error ? (
+        <p
+          role="alert"
+          className="font-body text-sm text-rose"
+          data-testid="buyer-categories-error"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      {saved && mode === "edit" ? (
+        <p
+          className="font-body text-sm text-green-700"
+          data-testid="buyer-categories-saved"
+        >
+          Préférences enregistrées.
+        </p>
+      ) : null}
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="inline-flex items-center justify-center rounded-pill bg-green-600 px-6 py-3.5 font-body text-sm font-semibold text-cream-50 shadow-sm hover:bg-green-700 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {submitting
+          ? "Enregistrement…"
+          : mode === "edit"
+            ? "Enregistrer"
+            : "Continuer"}
+      </button>
+    </form>
+  )
+}

--- a/apps/web/lib/buyer/adapters.ts
+++ b/apps/web/lib/buyer/adapters.ts
@@ -1,4 +1,5 @@
 import {
+  type BuyerCategoriesAdapter,
   type BuyerProfile,
   type BuyerProfileAdapter,
   type BuyerProfilePatch,
@@ -27,6 +28,7 @@ function toBuyerProfile(row: BuyerProfileRow, hasLocation: boolean): BuyerProfil
     city: row.city,
     postcode: row.postcode,
     has_location: hasLocation,
+    preferred_categories: row.preferred_categories,
   }
 }
 
@@ -72,6 +74,27 @@ export function getBuyerProfileAdapter(client: Client): BuyerProfileAdapter {
 
     async setLocation(longitude, latitude) {
       await buyerProfilesRepo.setLocationViaRpc(client, longitude, latitude)
+    },
+  }
+}
+
+/**
+ * Implémentation de `BuyerCategoriesAdapter` (KAN-26). Upsert idempotent de
+ * `preferred_categories` : crée la row acheteur si absente, sinon met à jour,
+ * sans jamais toucher la zone. Recalcule `has_location` après coup (la
+ * geography n'est pas projetée par le repo).
+ */
+export function getBuyerCategoriesAdapter(
+  client: Client,
+): BuyerCategoriesAdapter {
+  return {
+    async setCategories(userId, categories) {
+      const existing = await buyerProfilesRepo.findByUserId(client, userId)
+      const patch = { preferred_categories: categories }
+      const row = existing
+        ? await buyerProfilesRepo.update(client, userId, patch)
+        : await buyerProfilesRepo.create(client, userId, patch)
+      return toBuyerProfile(row, await hasLocation(client, userId))
     },
   }
 }

--- a/packages/contracts/src/buyer-profile/profile.test.ts
+++ b/packages/contracts/src/buyer-profile/profile.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { BuyerProfileUpsertInput } from "./profile"
+import { BuyerCategoriesInput, BuyerProfileUpsertInput } from "./profile"
 
 describe("BuyerProfileUpsertInput", () => {
   it("accepte une adresse seule (nom et coords facultatifs)", () => {
@@ -55,6 +55,52 @@ describe("BuyerProfileUpsertInput", () => {
     const r = BuyerProfileUpsertInput.safeParse({
       address_label: "14 rue de Lévis 75017 Paris",
       display_name: "M",
+    })
+    expect(r.success).toBe(false)
+  })
+})
+
+describe("BuyerCategoriesInput", () => {
+  it("accepte un sous-ensemble de catégories whitelistées", () => {
+    const r = BuyerCategoriesInput.safeParse({
+      preferred_categories: ["fruits", "legumes", "miel_et_ruche"],
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it("accepte une liste vide", () => {
+    const r = BuyerCategoriesInput.safeParse({ preferred_categories: [] })
+    expect(r.success).toBe(true)
+  })
+
+  it("rejette une catégorie hors whitelist", () => {
+    const r = BuyerCategoriesInput.safeParse({
+      preferred_categories: ["fromage_frais"],
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it("rejette plus de 8 catégories", () => {
+    const r = BuyerCategoriesInput.safeParse({
+      preferred_categories: [
+        "miel_et_ruche",
+        "fruits",
+        "legumes",
+        "cereales_legumineuses",
+        "conserves_confitures",
+        "pain_biscuits",
+        "huiles",
+        "boissons_non_alcoolisees",
+        "fruits",
+      ],
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it("rejette une clé inconnue (strict)", () => {
+    const r = BuyerCategoriesInput.safeParse({
+      preferred_categories: ["fruits"],
+      foo: "bar",
     })
     expect(r.success).toBe(false)
   })

--- a/packages/contracts/src/buyer-profile/profile.ts
+++ b/packages/contracts/src/buyer-profile/profile.ts
@@ -1,11 +1,14 @@
 import { z } from "zod"
 
+import { ProductCategory } from "../product/shared"
+
 /**
- * Profil acheteur — zone d'habitation (KAN-25).
+ * Profil acheteur — zone d'habitation (KAN-25) + préférences catégories (KAN-26).
  *
  * Consommé par :
- *   - GET /api/v1/me/buyer-profile  (snapshot, null si non créé)
- *   - PUT /api/v1/me/buyer-profile  (upsert : onboarding KAN-81 + édition KAN-82)
+ *   - GET /api/v1/me/buyer-profile             (snapshot, null si non créé)
+ *   - PUT /api/v1/me/buyer-profile             (upsert zone : onboarding KAN-81 + édition KAN-82)
+ *   - PUT /api/v1/me/buyer-profile/categories  (préférences : onboarding KAN-83 + édition KAN-84)
  *
  * La zone est géocodée côté client via l'API Adresse Gouv.fr ; les
  * coordonnées (latitude/longitude) accompagnent le label retenu. Le serveur
@@ -67,8 +70,35 @@ export const BuyerProfileUpsertInput = z
 export type BuyerProfileUpsertInput = z.infer<typeof BuyerProfileUpsertInput>
 
 /**
+ * Nombre de catégories produit existantes (enum `product_category`). Borne
+ * haute de `preferred_categories` : une préférence ne peut excéder le
+ * catalogue de catégories.
+ */
+const PRODUCT_CATEGORY_COUNT = 8
+
+/**
+ * Input des préférences catégories acheteur (KAN-26 — KAN-83 onboarding +
+ * KAN-84 paramètres). Sous-ensemble de l'enum `product_category` ; liste vide
+ * autorisée (« aucune préférence »). Endpoint dédié
+ * `PUT /api/v1/me/buyer-profile/categories` pour ne pas toucher au contrat
+ * d'upsert de la zone (qui exige `address_label`) — cf. specs/KAN-26/notes.md.
+ */
+export const BuyerCategoriesInput = z
+  .object({
+    preferred_categories: z
+      .array(ProductCategory)
+      .max(
+        PRODUCT_CATEGORY_COUNT,
+        "Trop de catégories sélectionnées.",
+      ),
+  })
+  .strict()
+export type BuyerCategoriesInput = z.infer<typeof BuyerCategoriesInput>
+
+/**
  * Snapshot renvoyé par GET / PUT. `has_location` indique si une zone
  * géocodée est posée (la geography brute n'est jamais exposée).
+ * `preferred_categories` liste les centres d'intérêt déclarés (KAN-26).
  */
 export const BuyerProfileSnapshot = z.object({
   display_name: z.string().nullable(),
@@ -76,6 +106,7 @@ export const BuyerProfileSnapshot = z.object({
   city: z.string().nullable(),
   postcode: z.string().nullable(),
   has_location: z.boolean(),
+  preferred_categories: z.array(ProductCategory),
 })
 export type BuyerProfileSnapshot = z.infer<typeof BuyerProfileSnapshot>
 

--- a/packages/core/src/buyer-profile/adapters.ts
+++ b/packages/core/src/buyer-profile/adapters.ts
@@ -5,13 +5,16 @@
  * producer (même API Adresse Gouv.fr).
  */
 
+import { type ProductCategory } from "@delta/contracts/product"
+
 export type { GeocodeAdapter, GeocodeResult } from "../producer/adapters"
 
 /**
  * Forme métier du profil acheteur partagée entre core et adapters.
  * Doublonne volontairement `BuyerProfileRow` de `@delta/db`. `has_location`
  * indique si une zone géocodée est posée (la geography brute ne traverse
- * jamais le core).
+ * jamais le core). `preferred_categories` liste les centres d'intérêt
+ * déclarés (KAN-26 — clés de l'enum `product_category`).
  */
 export type BuyerProfile = {
   user_id: string
@@ -20,6 +23,7 @@ export type BuyerProfile = {
   city: string | null
   postcode: string | null
   has_location: boolean
+  preferred_categories: ProductCategory[]
 }
 
 /** Patch des champs non-géo. La `location` passe par `setLocation`. */
@@ -42,6 +46,22 @@ export type BuyerProfileAdapter = {
    * nuls réinitialisent la position.
    */
   setLocation(longitude: number | null, latitude: number | null): Promise<void>
+}
+
+/**
+ * Adapter d'écriture des préférences catégories (KAN-26). Séparé de
+ * `BuyerProfileAdapter` car le use case catégories n'a pas besoin du géocodage.
+ */
+export type BuyerCategoriesAdapter = {
+  /**
+   * Upsert idempotent de `preferred_categories` : crée la row acheteur si
+   * absente, sinon met à jour. Retourne le profil complet (avec `has_location`
+   * préservé — l'écriture des catégories ne touche jamais la zone).
+   */
+  setCategories(
+    userId: string,
+    categories: ProductCategory[],
+  ): Promise<BuyerProfile>
 }
 
 export type BuyerRoleChecker = {

--- a/packages/core/src/buyer-profile/index.ts
+++ b/packages/core/src/buyer-profile/index.ts
@@ -1,2 +1,3 @@
 export * from "./adapters"
 export * from "./upsert-profile"
+export * from "./update-categories"

--- a/packages/core/src/buyer-profile/update-categories.test.ts
+++ b/packages/core/src/buyer-profile/update-categories.test.ts
@@ -1,0 +1,127 @@
+import { type ProductCategory } from "@delta/contracts/product"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  BuyerRoleForbiddenError,
+  BuyerValidationError,
+  RateLimitedError,
+} from "../errors"
+import { type RateLimitStore } from "../rate-limit/rate-limit"
+
+import { type BuyerProfile } from "./adapters"
+import {
+  BUYER_CATEGORIES_RATE_LIMIT,
+  updateBuyerCategories,
+} from "./update-categories"
+
+const USER_ID = "user-1"
+
+function noopStore(): RateLimitStore {
+  return {
+    incrementAndExpire: () =>
+      Promise.resolve({
+        count: 1,
+        ttlMs: BUYER_CATEGORIES_RATE_LIMIT.windowMs,
+      }),
+  }
+}
+
+function exhaustedStore(): RateLimitStore {
+  return {
+    incrementAndExpire: () => Promise.resolve({ count: 999, ttlMs: 30_000 }),
+  }
+}
+
+function makeProfile(categories: ProductCategory[]): BuyerProfile {
+  return {
+    user_id: USER_ID,
+    display_name: null,
+    address_label: "14 rue de Lévis 75017 Paris",
+    city: "Paris",
+    postcode: "75017",
+    has_location: true,
+    preferred_categories: categories,
+  }
+}
+
+function makeDeps(
+  overrides: Partial<Parameters<typeof updateBuyerCategories>[2]> = {},
+) {
+  const setCategories = vi
+    .fn()
+    .mockImplementation((_uid: string, categories: ProductCategory[]) =>
+      Promise.resolve(makeProfile(categories)),
+    )
+  const hasBuyerRole = vi.fn().mockResolvedValue(true)
+  return {
+    setCategories,
+    hasBuyerRole,
+    store: noopStore(),
+    ...overrides,
+  }
+}
+
+describe("updateBuyerCategories", () => {
+  it("refuse un user sans rôle acheteur", async () => {
+    const deps = makeDeps({ hasBuyerRole: vi.fn().mockResolvedValue(false) })
+    await expect(
+      updateBuyerCategories({ preferred_categories: ["fruits"] }, USER_ID, deps),
+    ).rejects.toBeInstanceOf(BuyerRoleForbiddenError)
+    expect(deps.setCategories).not.toHaveBeenCalled()
+  })
+
+  it("applique le rate-limit", async () => {
+    const deps = makeDeps({ store: exhaustedStore() })
+    await expect(
+      updateBuyerCategories({ preferred_categories: ["fruits"] }, USER_ID, deps),
+    ).rejects.toBeInstanceOf(RateLimitedError)
+  })
+
+  it("rejette une catégorie hors whitelist", async () => {
+    const deps = makeDeps()
+    await expect(
+      updateBuyerCategories(
+        { preferred_categories: ["fromage_frais"] },
+        USER_ID,
+        deps,
+      ),
+    ).rejects.toBeInstanceOf(BuyerValidationError)
+    expect(deps.setCategories).not.toHaveBeenCalled()
+  })
+
+  it("rejette une clé inconnue (strict)", async () => {
+    const deps = makeDeps()
+    await expect(
+      updateBuyerCategories(
+        { preferred_categories: ["fruits"], foo: "bar" },
+        USER_ID,
+        deps,
+      ),
+    ).rejects.toBeInstanceOf(BuyerValidationError)
+  })
+
+  it("accepte une liste vide (réinitialisation)", async () => {
+    const deps = makeDeps()
+    const result = await updateBuyerCategories(
+      { preferred_categories: [] },
+      USER_ID,
+      deps,
+    )
+    expect(deps.setCategories).toHaveBeenCalledWith(USER_ID, [])
+    expect(result.preferred_categories).toEqual([])
+  })
+
+  it("dédoublonne les catégories en préservant l'ordre", async () => {
+    const deps = makeDeps()
+    const result = await updateBuyerCategories(
+      { preferred_categories: ["fruits", "legumes", "fruits"] },
+      USER_ID,
+      deps,
+    )
+    expect(deps.setCategories).toHaveBeenCalledWith(USER_ID, [
+      "fruits",
+      "legumes",
+    ])
+    expect(result.preferred_categories).toEqual(["fruits", "legumes"])
+  })
+})

--- a/packages/core/src/buyer-profile/update-categories.ts
+++ b/packages/core/src/buyer-profile/update-categories.ts
@@ -1,0 +1,75 @@
+import { BuyerCategoriesInput } from "@delta/contracts/buyer-profile"
+
+import {
+  BuyerRoleForbiddenError,
+  BuyerValidationError,
+  RateLimitedError,
+} from "../errors"
+import { rateLimit, type RateLimitStore } from "../rate-limit/rate-limit"
+
+import {
+  type BuyerCategoriesAdapter,
+  type BuyerProfile,
+  type BuyerRoleChecker,
+} from "./adapters"
+
+export type UpdateBuyerCategoriesDeps = BuyerCategoriesAdapter &
+  BuyerRoleChecker & {
+    store: RateLimitStore
+  }
+
+/**
+ * Politique rate-limit pour `PUT /api/v1/me/buyer-profile/categories` : 30
+ * écritures par heure et par user (aligné sur l'upsert zone).
+ */
+export const BUYER_CATEGORIES_RATE_LIMIT = {
+  attempts: 30,
+  windowMs: 60 * 60_000,
+} as const
+
+/**
+ * Use case `updateBuyerCategories` (KAN-26 — KAN-83 onboarding + KAN-84 édition).
+ *
+ * Étapes :
+ *   1. Vérifie le rôle acheteur (BuyerRoleForbiddenError sinon)
+ *   2. Rate-limit fenêtre fixe par user
+ *   3. Validation Zod (`BuyerCategoriesInput`)
+ *   4. Dédoublonnage des catégories (préserve l'ordre de première apparition)
+ *   5. Upsert des préférences (création lazy de la row si absente, sans
+ *      jamais toucher la zone)
+ *
+ * La liste vide est valide : elle réinitialise les préférences.
+ */
+export async function updateBuyerCategories(
+  input: unknown,
+  userId: string,
+  deps: UpdateBuyerCategoriesDeps,
+): Promise<BuyerProfile> {
+  if (!(await deps.hasBuyerRole(userId))) {
+    throw new BuyerRoleForbiddenError()
+  }
+
+  const limit = await rateLimit(
+    `buyer:categories:${userId}`,
+    BUYER_CATEGORIES_RATE_LIMIT.attempts,
+    BUYER_CATEGORIES_RATE_LIMIT.windowMs,
+    deps.store,
+  )
+  if (!limit.allowed) {
+    throw new RateLimitedError(limit.retryAfterMs)
+  }
+
+  const parsed = BuyerCategoriesInput.safeParse(input)
+  if (!parsed.success) {
+    throw new BuyerValidationError(
+      "Validation des préférences échouée.",
+      parsed.error.issues.map((i) => ({
+        path: i.path.join("."),
+        message: i.message,
+      })),
+    )
+  }
+
+  const categories = [...new Set(parsed.data.preferred_categories)]
+  return deps.setCategories(userId, categories)
+}

--- a/packages/core/src/buyer-profile/upsert-profile.test.ts
+++ b/packages/core/src/buyer-profile/upsert-profile.test.ts
@@ -39,6 +39,7 @@ function makeProfile(overrides: Partial<BuyerProfile> = {}): BuyerProfile {
     city: "Paris",
     postcode: "75017",
     has_location: false,
+    preferred_categories: [],
     ...overrides,
   }
 }

--- a/packages/db/src/buyer-profiles/repo.ts
+++ b/packages/db/src/buyer-profiles/repo.ts
@@ -9,7 +9,7 @@ import {
 type Client = SupabaseClient<Database>
 
 const SELECT_COLUMNS =
-  "user_id, display_name, address_label, city, postcode, created_at, updated_at, deleted_at"
+  "user_id, display_name, address_label, city, postcode, preferred_categories, created_at, updated_at, deleted_at"
 
 /**
  * Repo `buyer_profiles` (KAN-25). Profil acheteur minimal (nom + zone)

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -351,6 +351,8 @@ export type BuyerProfileRow = {
   address_label: string | null
   city: string | null
   postcode: string | null
+  // Sous-ensemble de product_category déclaré comme centres d'intérêt (KAN-26).
+  preferred_categories: ProductCategory[]
   created_at: string
   updated_at: string
   deleted_at: string | null
@@ -362,6 +364,7 @@ export type BuyerProfileInsert = {
   address_label?: string | null
   city?: string | null
   postcode?: string | null
+  preferred_categories?: ProductCategory[]
   deleted_at?: string | null
 }
 
@@ -370,5 +373,6 @@ export type BuyerProfileUpdate = {
   address_label?: string | null
   city?: string | null
   postcode?: string | null
+  preferred_categories?: ProductCategory[]
   deleted_at?: string | null
 }

--- a/specs/KAN-26/notes.md
+++ b/specs/KAN-26/notes.md
@@ -1,0 +1,58 @@
+# Notes d'implémentation — KAN-26 Préférences catégories
+
+## Déviations vs cadrage / maquette (pour arbitrage)
+
+### 1. Taxonomie maquette AC-02 ↔ enum `product_category` (arbitrage produit)
+
+La maquette `design/maquettes/acheteur/ac-02-onboarding.html` (étape 2) liste
+8 chips d'une taxonomie distincte de l'enum produit réel :
+
+| Maquette | Enum `product_category` |
+|---|---|
+| Miel & confitures | `miel_et_ruche` + `conserves_confitures` (scindé) |
+| Produits laitiers secs | *(absent — pas de catégorie laitages)* |
+| Œufs | *(absent)* |
+| Farines & céréales | `cereales_legumineuses` |
+| Légumes robustes | `legumes` |
+| Fruits | `fruits` |
+| Conserves artisanales | `conserves_confitures` |
+| Légumineuses | `cereales_legumineuses` |
+| *(absent maquette)* | `pain_biscuits`, `huiles`, `boissons_non_alcoolisees` |
+
+**Décision tech retenue** : les chips sont pilotés par l'enum `product_category`
+(`PRODUCT_CATEGORIES` / `PRODUCT_CATEGORY_FR` / `PRODUCT_CATEGORY_EMOJI`), **pas**
+par la liste en dur de la maquette. Sans cet alignement, une préférence ne
+pourrait ni filtrer ni trier le catalogue (KAN-28), qui ne connaît que
+`product_category`. Les libellés/emoji affichés sont donc ceux du contrat.
+
+**À arbitrer côté produit** : si la taxonomie acheteur doit différer de la
+taxonomie producteur (catégories marketing distinctes des catégories de mise en
+vente), il faudra une table de correspondance dédiée — hors périmètre KAN-26.
+
+### 2. Endpoint dédié plutôt qu'extension de `PUT /api/v1/me/buyer-profile`
+
+Le cadrage (`design.md`) recommandait d'étendre l'endpoint d'upsert de KAN-25.
+À l'implémentation, deux contraintes du code KAN-25 l'ont rendu risqué :
+
+- `BuyerProfileUpsertInput` **exige** `address_label` (≥ 5 car.) : un payload
+  catégories-seul ne le satisferait pas sans rendre le champ optionnel.
+- `upsertBuyerProfile` appelle `setLocation(null, null)` dès qu'aucune coordonnée
+  n'est fournie : une écriture catégories-seul **réinitialiserait la zone**.
+
+**Décision** : endpoint dédié `PUT /api/v1/me/buyer-profile/categories`
+(use case `updateBuyerCategories`, contrat `BuyerCategoriesInput`,
+adapter `BuyerCategoriesAdapter.setCategories`). Le chemin zone de KAN-25 reste
+strictement inchangé ; seul le `BuyerProfileSnapshot` (lecture) est étendu avec
+`preferred_categories`. C'est l'option granulaire signalée comme alternative
+dans `proposal.md` § Hypothèses.
+
+## Écarts mineurs
+
+- **Chips non promus dans `packages/ui-web`** : le composant
+  `BuyerCategoriesForm` vit dans `apps/web/components/buyer/` (partagé entre
+  onboarding et paramètres), cohérent avec le choix KAN-24 de ne pas promouvoir
+  le pattern chips. La case `packages/ui-web` du `design.md` est donc traitée
+  par un composant `apps/web` partagé plutôt qu'un export ui-web.
+- **Wizard onboarding à 2 étapes** : l'onboarding acheteur passe de 1 (KAN-25)
+  à 2 étapes (zone → catégories). L'étape 3 notifications de la maquette reste
+  hors périmètre (KAN-14).

--- a/supabase/migrations/20260612120000_buyer_profiles_preferred_categories.sql
+++ b/supabase/migrations/20260612120000_buyer_profiles_preferred_categories.sql
@@ -1,0 +1,26 @@
+-- Migration: buyer_profiles_preferred_categories
+-- Date: 2026-06-12
+-- Ticket: KAN-26 (Préférences catégories)
+-- Cadrage: specs/KAN-26/design.md, ARCHITECTURE.md §5
+--
+-- Ajoute la colonne public.buyer_profiles.preferred_categories : sous-ensemble
+-- de l'enum product_category (KAN-20) que l'acheteur déclare comme centres
+-- d'intérêt. Capté à l'onboarding (AC-02 étape 2, KAN-83) et éditable depuis
+-- les paramètres (AC-11, KAN-84). Personnalise l'affichage de l'accueil
+-- (tri / mise en avant, KAN-28) — jamais un filtre dur ni un impact matching.
+--
+-- Réutilise le type enum product_category déjà créé par la migration KAN-20
+-- (20260518000000_create_products.sql) : aucun CREATE TYPE ici. La RLS de la
+-- table (policies *_self de KAN-25) couvre la nouvelle colonne sans changement.
+--
+-- Rollback documenté :
+--   ALTER TABLE public.buyer_profiles DROP COLUMN IF EXISTS preferred_categories;
+--
+-- Migration idempotente (ADD COLUMN IF NOT EXISTS).
+
+ALTER TABLE public.buyer_profiles
+  ADD COLUMN IF NOT EXISTS preferred_categories public.product_category[]
+  NOT NULL DEFAULT '{}';
+
+COMMENT ON COLUMN public.buyer_profiles.preferred_categories IS
+  'Catégories produit (sous-ensemble de l''enum product_category) déclarées comme centres d''intérêt par l''acheteur (KAN-26). Vide = aucune préférence. Personnalise l''accueil (KAN-28), pas un filtre dur.';


### PR DESCRIPTION
Implémentation de **KAN-26 — Préférences catégories** (epic KAN-6 Profil Acheteur). Cadrage : `specs/KAN-26/`.

## Subtasks Jira couvertes
- **KAN-83** — Indiquer ses préférences de catégories à l'onboarding (AC-02 étape 2)
- **KAN-84** — Modifier ses préférences depuis les paramètres (AC-11)

## Ce qui est livré
- **DB** : colonne `buyer_profiles.preferred_categories product_category[] NOT NULL DEFAULT '{}'` (migration `20260612120000`, réutilise l'enum `product_category` de KAN-20, RLS inchangée).
- **Contrats** : `BuyerCategoriesInput` (sous-ensemble de `product_category`, ≤ 8, liste vide OK, `.strict()`) + `BuyerProfileSnapshot` étendu avec `preferred_categories`.
- **Core** : use case `updateBuyerCategories` (rôle acheteur + rate-limit + validation + dédoublonnage) + `BuyerCategoriesAdapter`.
- **API** : endpoint dédié `PUT /api/v1/me/buyer-profile/categories` ; `GET`/`PUT` zone exposent désormais `preferred_categories`.
- **Web** : composant partagé `BuyerCategoriesForm` (grille de chips pilotée par `PRODUCT_CATEGORIES`/`…_FR`/`…_EMOJI`), wizard onboarding acheteur passé à 2 étapes (zone → catégories), section « Mes catégories d'intérêt » dans `/acheteur/profil`.

## Décisions notables (détaillées dans `specs/KAN-26/notes.md`)
- **Taxonomie** : les chips suivent l'enum `product_category` réel, pas la liste de la maquette (laitages/œufs absents de l'enum) — sinon tri/filtrage AC-03 impossible. À arbitrer côté produit si une taxonomie acheteur distincte est voulue.
- **Endpoint dédié** plutôt qu'extension du `PUT` zone : ce dernier exige `address_label` et réinitialise la zone si aucune coordonnée n'est envoyée — un write catégories-seul l'aurait cassé. Le chemin zone de KAN-25 reste intact.

## Vérifications
- `pnpm lint` ✅ (0 erreur) · `pnpm typecheck` ✅ · `pnpm test` ✅ (contracts 173, core 219, dont les nouveaux tests `BuyerCategoriesInput` + `updateBuyerCategories`).
- `pnpm build` échoue **uniquement** en sandbox (fetch Google Fonts bloqué par le proxy) — sans rapport avec le code ; passera en CI.

🔗 https://erkulaws.atlassian.net/browse/KAN-26

https://claude.ai/code/session_013GDE2dr3884ngeYFqKJp48

---
_Generated by [Claude Code](https://claude.ai/code/session_013GDE2dr3884ngeYFqKJp48)_