### PR TITLE
specs KAN-27 — Historique commandes (cadrage)

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -52,7 +52,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | AC-08 Mes commandes | `ac-08-mes-commandes.html` | KAN-45 (Suivi mission & états) | KAN-55 (Notif in-app) |
 | AC-08b QR delivery | `ac-08b-qr-delivery.html` | KAN-48 (QR Delivery) | — |
 | AC-08bis Profil public producteur | `ac-08bis-profil-producteur.html` | KAN-53 (Profils publics & avis) | — |
-| AC-09 Historique commandes | `ac-09-historique.html` | KAN-27 (Historique commandes) | KAN-36 (Factures PDF) |
+| AC-09 Historique commandes | `ac-09-historique.html` | KAN-27 (Historique commandes) — [Cadrage tech](specs/KAN-27/) | KAN-36 (Factures PDF) |
 | AC-10 Évaluation post-livraison | `ac-10-evaluation.html` | KAN-52 (Notation post-livraison) | — |
 | AC-11 Profil + paramètres | `ac-11-profil.html` | KAN-26 (Préférences catégories), KAN-25 (Onboarding & zone) | [Cadrage KAN-25](specs/KAN-25/), [Cadrage KAN-26](specs/KAN-26/) |
 | AC-12 Zone non couverte | `ac-12-zone-non-couverte.html` | KAN-29 (Zone non couverte & liste d'attente) | — |
@@ -130,7 +130,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | KAN-6 | Epic | Ideas | Profil Acheteur |
 | KAN-25 | Feature | Examiner | Onboarding & zone — [Cadrage tech](specs/KAN-25/) — mergé sur main (PR #53) |
 | KAN-26 | Feature | Examiner | Préférences catégories — [Cadrage tech](specs/KAN-26/) — mergé sur main (PR #57) |
-| KAN-27 | Feature | Ideas | Historique commandes |
+| KAN-27 | Feature | Ideas | Historique commandes — [Cadrage tech](specs/KAN-27/) |
 
 ### KAN-7 — Wishlist & Matching
 

--- a/specs/KAN-27/design.md
+++ b/specs/KAN-27/design.md
@@ -1,0 +1,139 @@
+# Conception technique — KAN-27 Historique commandes
+
+## Vue d'ensemble
+
+Page de route Next.js autonome `/acheteur/historique`, Server Component qui ne
+lit que la session + le rôle (via `supabase.auth.getUser()` + `usersRepo`),
+comme `/acheteur/profil` (KAN-25). Aucune table de commandes n'existant, la page
+est entièrement en empty state : header, 3 stat cards désactivées, rangée de
+filtres désactivée, et une section liste avec `<EmptyState />`. Aucun nouveau
+endpoint, aucun use case core, aucune migration. L'enjeu : poser l'enveloppe
+acheteur AC-09 et une structure de composants prête à se câbler quand
+`missions` / `mission_buyers` / paiements / KAN-36 arriveront. Même posture que
+KAN-19 côté producteur.
+
+## Packages touchés
+
+- [ ] `packages/contracts` — aucun
+- [ ] `packages/core` — aucun
+- [ ] `packages/db` — aucun (lecture session/rôle via `usersRepo` existant ;
+      helper d'agrégation `getBuyerOrderHistory` introduit seulement quand au
+      moins une table de commandes existera)
+- [x] `apps/web` — page `acheteur/historique/page.tsx`, composants
+      `apps/web/components/buyer/history/*`
+- [ ] `apps/mobile` — hors scope
+- [ ] `packages/jobs` — aucun
+- [ ] `supabase/migrations` — aucune
+- [ ] `supabase/policies` — aucune
+- [ ] `packages/ui-web` — non (composants locaux `components/buyer/`, comme KAN-25/26)
+
+## Modèle de données
+
+Référence : ARCHITECTURE.md §5.
+
+Aucune extension. Tables lues au MVP KAN-27 : `users` (rôle/gating, déjà câblé).
+La page n'affiche aucune commande.
+
+Sources futures (post-KAN-27, à câbler incrémentalement) :
+
+- `missions` + `mission_buyers` + `products` (KAN-10 / KAN-11) → lignes de commande
+- `users` + `vehicles` → résolution nom rameneur par commande
+- paiements / escrow (KAN-33 / KAN-34) → montants, total dépensé
+- `trips` (KAN-10) → calcul « km évités »
+- KAN-36 → URL facture PDF par commande
+- KAN-52 → note attribuée affichée sur chaque ligne
+
+## API / Endpoints
+
+Référence : ARCHITECTURE.md §3.
+
+Aucun nouveau endpoint. Le gating session + rôle est fait en Server Component.
+
+Quand les commandes deviendront dynamiques, deux options (décision déférée) :
+1. lecture server-side directe dans la page (pattern KAN-25)
+2. endpoint `GET /api/v1/me/orders?from=…&to=…&producer=…&category=…` pour
+   filtres / pagination client
+
+## Impact state machine / events
+
+Référence : ARCHITECTURE.md §6 et §8.
+
+Aucun. Page strictement read-only, aucune transition mission, aucun event Inngest.
+
+## Dépendances
+
+Référence : ARCHITECTURE.md §2. Provisionnement : `tech/setup.md`.
+
+- **Supabase Postgres** — session + lecture `users` (déjà câblé KAN-25), cf.
+  `tech/setup.md` § Supabase. Aucun nouveau service.
+- **Stripe** — statut *Partiel* (`tech/setup.md` § Stripe Connect Express) ;
+  KAN-27 n'appelle ni l'API Stripe ni les webhooks. Dépendance réelle quand les
+  montants / factures seront câblés (KAN-33/34/36).
+- Internes : gating `/acheteur/profil` (KAN-25), primitives empty state / cards
+  producteur (KAN-18/19) si mutualisables, tokens DESIGN.md, icônes lucide-react.
+
+## État UI
+
+Référence : DESIGN.md (tokens, breakpoints), maquette
+`design/maquettes/acheteur/ac-09-historique.html`.
+
+- **`/acheteur/historique/page.tsx`** — Server Component : `getUser()` → si pas
+  de session `redirect("/login")` ; charge `usersRepo.findById`, si rôle
+  `acheteur` absent `redirect("/onboarding/role")` (calqué KAN-25).
+- **Header** : `<h1>Historique</h1>` (Lora) + sous-titre « Toutes vos commandes
+  livrées · factures téléchargeables ».
+- **`<HistoryStats />`** : 3 stat cards (Commandes / Total dépensé / Km évités)
+  en variant empty (valeur `—`, meta « Disponible bientôt »). Aucun chiffre
+  mocké (la maquette montre 14 / 421 € / 186 — non repris).
+- **`<HistoryFilters />`** : chips période / producteur / catégorie + bouton
+  « Exporter CSV », tous `aria-disabled` + tooltip « Disponible une fois vos
+  premières commandes enregistrées ». Pas de callback `onClick`.
+- **`<HistoryList />`** : `<EmptyState />` (« Aucune commande pour l'instant.
+  Vos commandes livrées apparaîtront ici. »). Pas de month-divider ni d'order-card
+  au MVP. Quand câblé : regroupement par mois (divider + total), order-card
+  (image produit, nom, date, producteur, rameneur, note, montant, actions
+  facture PDF / recommander) — conforme maquette.
+- **Responsive** : stats `repeat(3, 1fr)` desktop → empilées / 1 colonne en
+  mobile (< 600 px, breakpoint maquette) ; filtres scroll horizontal sans
+  scrollbar visible ; bottom-nav mobile / header desktop selon la maquette
+  (la nav globale réelle viendra avec KAN-28). Mobile + desktop obligatoires.
+
+## Risques techniques
+
+Références : ARCHITECTURE.md §9, §11, §13.
+
+- **Tentation de mocker des commandes** : la maquette est riche (stats chiffrées,
+  5 order-cards, notes, factures). Règle KAN-18/19 reprise telle quelle —
+  **aucune fixture en prod**, uniquement empty states. Les fixtures vivent dans
+  les tests, pas dans le bundle.
+- **Filtres / stats rendus mais inactifs** : `aria-disabled` + tooltip explicite,
+  pas de fausse interaction.
+- **Bouton « Facture » couplé à KAN-36** : aucune ligne au MVP → aucun bouton
+  rendu, pas de dette. Penser à l'`aria-disable` au câblage si KAN-36 pas encore
+  livré.
+- **Action « Recommander »** : dépend du parcours d'achat (KAN-28/30/33), non
+  rendue au MVP.
+- **Pas de shell acheteur** : `/acheteur/historique` est autonome (URL directe),
+  comme `/acheteur/profil`. La nav globale (lien vers l'historique) est branchée
+  par KAN-28 — ne pas dupliquer un layout acheteur ici.
+- **Bundle** : page légère (3-4 composants en empty state), cible bundle
+  `/acheteur/*` respectée (ARCHITECTURE.md §11 / §13).
+
+## Tests envisagés
+
+Référence : ARCHITECTURE.md §10.
+
+- **Unit `packages/core`** : aucun (pas de logique métier).
+- **Unit `apps/web`** (Vitest + RTL) :
+  - `<HistoryStats />` rend 3 cards en empty state (valeur `—`).
+  - `<HistoryFilters />` rend les chips + « Exporter CSV » en `aria-disabled`.
+  - `<HistoryList />` rend l'`<EmptyState />` avec la microcopy attendue.
+- **E2E web Playwright** (`apps/web/e2e/buyer-history.spec.ts`) :
+  - Acheteur connecté → `/acheteur/historique` : voit header + stats + filtres +
+    empty state, sans erreur console.
+  - Non-connecté → redirect `/login`.
+  - Connecté sans rôle acheteur → redirect `/onboarding/role` (cohérent KAN-25,
+    pas de duplication).
+  - Responsive mobile (< 600 px) : stats empilées, filtres scrollables, pas de
+    débordement horizontal.
+- **Accessibilité** : axe-core sur `/acheteur/historique` (0 violation critique).

--- a/specs/KAN-27/proposal.md
+++ b/specs/KAN-27/proposal.md
@@ -1,0 +1,66 @@
+# Cadrage — KAN-27 Historique commandes
+
+## Liens
+
+- Jira : https://erkulaws.atlassian.net/browse/KAN-27
+- Epic : KAN-6 Profil Acheteur
+- Maquette : design/maquettes/acheteur/ac-09-historique.html
+- PRD : §10.3 AC-09
+- ARCHITECTURE : §5 (DB lecture / RLS), §8 (Stripe — montants / factures, déféré), §14 (playbook)
+
+## Pourquoi (côté tech)
+
+L'écran AC-09 « Historique » liste les commandes **livrées** d'un acheteur :
+date, produit, producteur, rameneur, montant, note attribuée, facture PDF, et
+actions « recommander ». Côté produit c'est la mémoire d'achat de l'acheteur ;
+côté tech, aucune des tables qui l'alimentent n'existe encore au MVP — pas de
+`missions`, pas de `mission_buyers`, pas de commande payée ni livrée à ce jour
+(le parcours paiement KAN-33/34 et le cycle mission KAN-10/11 ne sont pas
+développés). KAN-27 livre donc **l'enveloppe** (route autonome gatée, sections,
+composants, navigation interne) en **empty state**, qui se câblera
+incrémentalement quand les tables arriveront. Exactement la même approche que
+KAN-19 (historique ventes producteur) et cohérente avec `/acheteur/profil`
+(KAN-25), page acheteur autonome livrée avant le shell complet (KAN-28).
+
+## Périmètre technique
+
+**In scope :**
+
+- Route autonome `/acheteur/historique` (Server Component) avec gating session +
+  rôle `acheteur` calqué sur `/acheteur/profil` (KAN-25)
+- Header `<h1>Historique</h1>` + sous-titre « Toutes vos commandes livrées ·
+  factures téléchargeables »
+- 3 stat cards (Commandes, Total dépensé, Km évités) rendues en empty state
+  (valeur `—` / « Disponible bientôt »), pas de chiffres mockés
+- Rangée de filtres (période / producteur / catégorie + « Exporter CSV »)
+  rendue en `aria-disabled` + tooltip neutre tant qu'aucune commande
+- Section liste : `<EmptyState />` (« Aucune commande pour l'instant. Vos
+  commandes livrées apparaîtront ici. ») — pas de month-dividers ni d'order-cards
+  au MVP
+- Structure de composants (`<HistoryStats />`, `<HistoryFilters />`,
+  `<HistoryList />`, futur `<OrderCard />`) prête à se câbler
+
+**Out of scope (cette US) :**
+
+- Lecture des commandes réelles (`missions` / `mission_buyers` / `products` /
+  `users` inexistantes)
+- Téléchargement de facture PDF — bouton « Facture » de la maquette (subtask
+  KAN-86) couvert fonctionnellement par **KAN-36** ; aucune ligne au MVP donc
+  aucun bouton rendu
+- Action « Recommander » (re-déclenche un parcours d'achat → dépend de
+  KAN-28/30/33), export CSV réel, filtres opérationnels
+- Calcul des « km évités » (nécessite trajets KAN-10) et des agrégats dépensés
+  (nécessite paiements KAN-33/34)
+- Version mobile native (Expo) — web d'abord, cohérent KAN-25/26
+- Shell acheteur complet (layout + nav globale + accueil AC-03) → KAN-28
+
+## Hypothèses
+
+- L'acheteur arrive sur `/acheteur/historique` par URL directe au MVP ; le lien
+  de nav globale sera branché par KAN-28 (shell acheteur)
+- Aucune nouvelle table, aucune nouvelle policy RLS, aucune migration
+- Réutilisation des primitives empty state / cards posées côté producteur
+  (KAN-18/19) si mutualisables, sinon composants locaux `components/buyer/`
+- Microcopy des empty states neutre, jamais de référence à un ticket interne
+- Les 3 stats et les filtres sont rendus désactivés (présents visuellement) —
+  pas masqués — pour rester fidèle à la maquette sans fausse interaction

--- a/specs/KAN-27/tasks.md
+++ b/specs/KAN-27/tasks.md
@@ -1,0 +1,29 @@
+# Tâches techniques internes — KAN-27 Historique commandes
+
+> Ces tâches ne sont pas dans Jira. Setup, migrations, refacto, helpers partagés,
+> seeds, configuration — tout ce qui n'a pas vocation à être tracké comme
+> livrable produit.
+>
+> Subtasks Jira existantes (rappel — ne pas dupliquer ici) :
+> - KAN-85 — Accéder à l'historique des commandes livrées
+> - KAN-86 — Télécharger la facture PDF d'une commande (couvert fonctionnellement par KAN-36)
+
+## Tâches
+
+- [ ] Vérifier la réutilisabilité des primitives empty state / cards posées en
+      KAN-18/19 (`<KpiCard />`, `<EmptyState />`, `<SectionCard />`) ; si trop
+      couplées au producteur, créer des équivalents locaux dans
+      `apps/web/components/buyer/history/`.
+- [ ] Factoriser le gating session + rôle acheteur si la duplication avec
+      `/acheteur/profil` devient gênante (helper `requireBuyer()` côté web) —
+      sinon laisser inline comme KAN-25.
+- [ ] Poser les composants `<HistoryStats />`, `<HistoryFilters />`,
+      `<HistoryList />` avec props prêtes à recevoir des données (typage de
+      `OrderHistoryRow` esquissé mais non câblé tant que les tables manquent).
+- [ ] Documenter dans le code (commentaire en tête de page) les sources futures
+      à câbler (missions / mission_buyers / paiements / KAN-36) — même convention
+      que `/acheteur/profil`.
+
+## Checklist pre-merge
+
+Voir ARCHITECTURE.md §14.3 — ne pas dupliquer ici.


### PR DESCRIPTION
Cadrage technique de **KAN-27 — Historique commandes** (écran AC-09, épic KAN-6 Profil Acheteur).

## Contenu

- `specs/KAN-27/proposal.md` — périmètre, in/out scope, hypothèses
- `specs/KAN-27/design.md` — conception technique (packages, data, UI, tests)
- `specs/KAN-27/tasks.md` — tâches techniques internes
- `produit/jira_mapping.md` — lien cadrage ajouté (table AC-09 + catalogue KAN-6)

## Approche

Empty-state shell calqué sur KAN-19 (historique ventes producteur) : les tables `missions` / `mission_buyers` / paiements n'existent pas encore, donc KAN-27 livre l'enveloppe (route autonome gatée `/acheteur/historique`, stats + filtres désactivés, liste en empty state) prête à se câbler quand les données arriveront. Aucune migration, aucun endpoint, aucun event.

- Subtask KAN-86 (facture PDF) renvoyée à KAN-36 — aucune ligne au MVP donc aucun bouton rendu.
- Page autonome comme `/acheteur/profil` (KAN-25) ; le shell + nav globale relèvent de KAN-28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwRBXNnpAXZUAdiqCCs8Bs)_