### PR TITLE
specs KAN-28 — Catalogue filtré

### DIFF
--- a/produit/jira_mapping.md
+++ b/produit/jira_mapping.md
@@ -43,9 +43,9 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 |-------|----------|-------------------------------|--------------|
 | AC-01 Inscription / connexion | `ac-01-authentication.html` | KAN-2 (Création de compte), KAN-3 (Connexion), KAN-157 (Récup. mot de passe) | [Cadrage KAN-2](specs/KAN-2/), [Cadrage KAN-3](specs/KAN-3/), [Cadrage KAN-157](specs/KAN-157/) |
 | AC-02 Onboarding | `ac-02-onboarding.html` | KAN-25 (Onboarding & zone), KAN-26 (Préférences catégories) | [Cadrage KAN-25](specs/KAN-25/), [Cadrage KAN-26](specs/KAN-26/) |
-| AC-03 Accueil | `ac-03-accueil.html` | KAN-28 (Catalogue filtré) | — |
-| AC-04 Catalogue parcourable | `ac-04-catalogue.html` | KAN-28 (Catalogue filtré) | KAN-29 (Zone non couverte) |
-| AC-05 Fiche produit | `ac-05-fiche-produit.html` | KAN-28 (Catalogue filtré) | KAN-30 (Wishlist privée) |
+| AC-03 Accueil | `ac-03-accueil.html` | KAN-28 (Catalogue filtré) — [Cadrage tech](specs/KAN-28/) | — |
+| AC-04 Catalogue parcourable | `ac-04-catalogue.html` | KAN-28 (Catalogue filtré) — [Cadrage tech](specs/KAN-28/) | KAN-29 (Zone non couverte) |
+| AC-05 Fiche produit | `ac-05-fiche-produit.html` | KAN-28 (Catalogue filtré) — [Cadrage tech](specs/KAN-28/) | KAN-30 (Wishlist privée) |
 | AC-06 Mes envies | `ac-06-mes-envies.html` | KAN-30 (Wishlist privée) | — |
 | AC-07 Notif match → confirmation | `ac-07-notification-match.html` | KAN-31 (Notification & confirmation match) | KAN-32 (Pénalités acheteur) |
 | AC-07b Paiement Stripe | `ac-07b-paiement.html` | KAN-33 (Paiement Stripe), KAN-34 (Escrow & libération) | — |
@@ -137,7 +137,7 @@ Source de vérité pour la correspondance entre tickets Jira (projet **KAN**, `e
 | Ticket | Type | Statut | Résumé |
 |--------|------|--------|--------|
 | KAN-7 | Epic | Ideas | Wishlist & Matching |
-| KAN-28 | Feature | Ideas | Catalogue filtré |
+| KAN-28 | Feature | Ideas | Catalogue filtré — [Cadrage tech](specs/KAN-28/) |
 | KAN-29 | Feature | Ideas | Zone non couverte & liste d'attente |
 | KAN-30 | Feature | Ideas | Wishlist privée |
 | KAN-31 | Feature | Ideas | Notification & confirmation match |

--- a/specs/KAN-28/design.md
+++ b/specs/KAN-28/design.md
@@ -1,0 +1,157 @@
+# Conception technique — KAN-28 Catalogue filtré
+
+## Vue d'ensemble
+
+Le mouvement principal : ouvrir un **chemin de lecture publique du catalogue**
+(produit + producteur public) et le câbler sur trois pages acheteur, le tout sous
+un nouveau **shell acheteur**. La donnée produit existe déjà (RLS
+`products_select_public`, FTS `search_vector`) ; l'inconnue est la projection
+producteur, car `producers` n'a pas de policy de lecture publique. On introduit
+donc une vue/RPC dédiée qui réutilise le prédicat de visibilité existant et
+n'expose qu'une whitelist de colonnes. Les pages sont des Server Components pour
+le rendu initial (SSR + gating rôle acheteur), avec un endpoint
+`GET /api/v1/catalogue` pour la recherche/filtre/pagination côté client. Aucune
+logique métier lourde, aucune state machine, aucun job.
+
+## Packages touchés
+
+- [x] `packages/contracts` — `CatalogueQuery` (input) + `CataloguePublicProduct`
+      (output)
+- [ ] `packages/core` — aucun (lecture pure ; un mince mapper DB→DTO peut vivre
+      dans `packages/db` ou `core` si réutilisé — à trancher à l'implémentation)
+- [x] `packages/db` — `catalogueRepo` (appel vue/RPC), types de projection
+- [x] `apps/web` — `acheteur/layout.tsx`, pages `acheteur/page.tsx`,
+      `acheteur/catalogue/page.tsx`, `acheteur/catalogue/[id]/page.tsx`,
+      endpoint `app/api/v1/catalogue/route.ts`, composants `components/buyer/*`
+- [ ] `apps/mobile` — hors scope
+- [ ] `packages/jobs` — aucun
+- [x] `supabase/migrations` — vue ou RPC catalogue public (+ éventuelle policy)
+- [ ] `supabase/policies` — pas de nouvelle policy table si on passe par RPC
+      SECURITY DEFINER ; à confirmer selon le mécanisme retenu
+- [ ] `packages/ui-web` — non (composants locaux `components/buyer/`, cohérent
+      KAN-25/26/27)
+
+## Modèle de données
+
+Référence : ARCHITECTURE.md §5.
+
+Aucune nouvelle table. **Décision structurante à valider** : comment exposer la
+projection catalogue publique alors que `producers` est `select_self` only.
+
+- **Contrainte** : la RLS étant row-level (pas column-level), ajouter
+  `producers_select_public` exposerait *toutes* les colonnes producteur (SIRET,
+  identifiants Stripe) à quiconque requête la table — inacceptable.
+- **Approche recommandée** : un **RPC SECURITY DEFINER** `catalogue_search(...)`
+  et `catalogue_get(id)` (ou une vue `public.catalogue_products` détenue par un
+  rôle privilégié) qui :
+  - réutilise **exactement** le prédicat de `products_select_public` (statut
+    `active`, non soft-deleted, fenêtre dispo, producteur vérifié + payouts +
+    non en pause) — DRY à garantir (cf. Risques) ;
+  - ne renvoie qu'une **whitelist** : `product.id`, `name`, `category`,
+    `packaging`, `unit_price_cents`, `labels`, `photos[0]`, + producteur public
+    (`display_name`, `city`) ;
+  - applique FTS (`websearch_to_tsquery('french', q)` + `ts_rank`) et le tri.
+- Mécanisme exact (RPC vs vue `security_invoker`) à arbitrer à l'implémentation ;
+  possible entrée ARCHITECTURE §18 (nouveau pattern « lecture catalogue public »).
+
+Champ « ville » producteur : confirmer la colonne disponible (profil KAN-17 /
+`producers`) ; à défaut, dériver de l'adresse de collecte sans exposer l'adresse
+exacte.
+
+## API / Endpoints
+
+Référence : ARCHITECTURE.md §3.
+
+- `GET /api/v1/catalogue?q=&category=&producer=&cursor=&limit=` →
+  `{ items: CataloguePublicProduct[], nextCursor: string | null }`.
+  Validation Zod (`CatalogueQuery`). Lecture via client utilisateur appelant la
+  vue/RPC. Tri : pertinence (`ts_rank`) si `q`, sinon récence. Pagination cursor.
+- Fiche produit AC-05 : lecture server-side directe dans
+  `acheteur/catalogue/[id]/page.tsx` via `catalogueRepo.getById` (pattern KAN-25),
+  pas d'endpoint dédié au MVP.
+- Codes d'erreur : `CATALOGUE_VALIDATION_FAILED`, `CATALOGUE_NOT_FOUND`
+  (fiche produit inexistante ou non visible → 404).
+
+## Impact state machine / events
+
+Référence : ARCHITECTURE.md §6 et §8.
+
+Aucun. Lecture strictement read-only, aucune transition mission, aucun event
+Inngest, aucun webhook.
+
+## Dépendances
+
+Référence : ARCHITECTURE.md §2. Provisionnement : `tech/setup.md`.
+
+- **Supabase Postgres** — FTS + RLS + vue/RPC, déjà provisionné, cf.
+  `tech/setup.md` § Supabase (Postgres + Auth + Storage + Realtime). Aucun
+  nouveau service externe.
+- **Supabase Storage** — lecture publique des photos produit (`product-photos`)
+  et producteur (`producer-photos`) déjà ouverte (policies `*_select_public`).
+- Internes : gating `/acheteur/profil` (KAN-25), `productsRepo` (KAN-20) pour
+  référence du modèle produit, tokens DESIGN.md, icônes lucide-react. Pas
+  d'API Adresse ni Stripe au runtime de KAN-28.
+
+## État UI
+
+Référence : DESIGN.md (tokens, breakpoints) + maquettes ac-03/04/05.
+
+- **`acheteur/layout.tsx`** (shell) : header (logo, nav desktop Accueil /
+  Catalogue / Mes envies / Commandes, cloche notifs, avatar) + bottom-nav mobile
+  (Accueil / Catalogue / Envies / Commandes / Profil). Liens « Mes envies » et
+  badge → cibles KAN-30 (rendus, inertes ou pointant vers placeholder).
+- **AC-03 `/acheteur`** : greeting « Bonjour {prénom} » ; « Découvrir des
+  producteurs » = grille réelle (producteurs vérifiés) ; « Disponible cette
+  semaine » et « Mes envies » en `<EmptyState>` / différé (pas de données mockées,
+  pas de notes ★) ; bannière impact CO₂ différée (placeholder neutre).
+- **AC-04 `/acheteur/catalogue`** : search bar (FTS), 2 rangées de chips —
+  **actives** : catégorie, producteur ; **différées** (`aria-disabled` + tooltip
+  « Disponible bientôt ») : Zone d'origine, Disponibilité, Trajet actif. Grille
+  responsive `repeat(2/3/4, 1fr)` (mobile/≥720/≥1000). Carte : image (photos[0]),
+  nom, producteur · ville, prix + unité. Badge trajet et bouton cœur non rendus
+  ou désactivés (→ KAN-30/42). Ligne résultats « N produits · M producteurs ».
+- **AC-05 `/acheteur/catalogue/[id]`** : galerie photos, nom, prix, producteur,
+  catégorie, labels, description. Bloc « match / trajets » et bouton « Ajouter aux
+  envies » rendus désactivés/différés (KAN-30/42). 404 si produit non visible.
+- **Responsive** : mobile + desktop obligatoires (DESIGN.md). Bottom-nav mobile /
+  header desktop. États vides neutres, jamais de fixture en prod.
+
+## Risques techniques
+
+Références : ARCHITECTURE.md §9, §11, §13.
+
+- **Divergence du prédicat de visibilité** : la vue/RPC duplique le prédicat de
+  `products_select_public`. Risque de désynchronisation si l'un évolue sans
+  l'autre. Mitigation : factoriser le prédicat (fonction SQL partagée) ou test
+  SQL qui compare les deux ensembles. À traiter explicitement.
+- **Exposition de colonnes producteur sensibles** : whitelist stricte (jamais
+  SIRET / Stripe / adresse exacte). Test dédié sur la projection.
+- **Tentation de mocker trajets / notes / envies** : maquettes très riches
+  (badges trajet, ★, match probable). Règle KAN-18/19/27 reprise — **aucune
+  fixture en prod**, uniquement réel ou empty/différé.
+- **Écart règle métier matchabilité** (PRD §12 H3) : catalogue non filtré par
+  trajet au MVP. À acter en décision produit, sinon flag rouge au review.
+- **Perf FTS + pagination** : index GIN existant ; valider le plan (cursor stable,
+  `ts_rank` borné, `limit` plafonné côté contrat).
+- **Non-régression KAN-25/27** : l'ajout de `acheteur/layout.tsx` enveloppe les
+  pages existantes — vérifier que leur gating et leur rendu ne cassent pas.
+- **Bundle** `/acheteur/*` : pages légères, cible bundle respectée (§11/§13).
+
+## Tests envisagés
+
+Référence : ARCHITECTURE.md §10.
+
+- **Unit `packages/contracts`** (Vitest) : `CatalogueQuery` (defaults, bornes
+  limit, q/category/producer optionnels) ; `CataloguePublicProduct` (forme).
+- **DB / intégration** (SQL ou via repo) : la vue/RPC **exclut** un produit
+  `draft`/`disabled`, un produit de producteur non vérifié / en pause / payouts
+  off, un produit hors fenêtre dispo, un soft-deleted ; **inclut** un produit
+  conforme ; la projection ne contient aucune colonne sensible.
+- **Unit `apps/web`** (RTL) : carte catalogue (image/nom/producteur/prix) ;
+  chips différées rendues `aria-disabled` ; empty states AC-03 ; bouton envie
+  désactivé.
+- **E2E web Playwright** : acheteur connecté → `/acheteur/catalogue` voit la
+  grille réelle ; recherche FTS filtre ; filtre catégorie filtre ; clic carte →
+  fiche AC-05 ; produit inexistant → 404 ; non-connecté → `/login` ; connecté
+  sans rôle acheteur → `/onboarding/role` (cohérent KAN-25) ; responsive mobile.
+- **Accessibilité** : axe-core sur AC-03/04/05 (0 violation critique).

--- a/specs/KAN-28/proposal.md
+++ b/specs/KAN-28/proposal.md
@@ -1,0 +1,91 @@
+# Cadrage — KAN-28 Catalogue filtré
+
+## Liens
+
+- Jira : https://erkulaws.atlassian.net/browse/KAN-28
+- Epic : KAN-7 Wishlist & Matching
+- Maquettes : design/maquettes/acheteur/ac-03-accueil.html,
+  design/maquettes/acheteur/ac-04-catalogue.html,
+  design/maquettes/acheteur/ac-05-fiche-produit.html
+- PRD : §10.3 AC-03 / AC-04 / AC-05 (parcours acheteur), §12 (logique écran, H3)
+- ARCHITECTURE : §3 (monorepo / API), §5 (DB / RLS), §7 (matching — différé),
+  §10 (tests), §14 (playbook)
+
+## Pourquoi (côté tech)
+
+KAN-28 livre la **première vue catalogue côté acheteur** sur trois écrans :
+AC-03 (accueil), AC-04 (catalogue parcourable), AC-05 (fiche produit). C'est
+aussi le ticket qui pose le **shell acheteur** (layout global : header desktop +
+bottom-nav mobile) que KAN-25 (onboarding/zone) et KAN-27 (historique) ont
+explicitement différé — leurs pages `/acheteur/*` autonomes seront rétro-wrappées
+par ce layout.
+
+Bonne nouvelle : la couche données catalogue **existe déjà**. La policy RLS
+`products_select_public` (migration KAN-20) expose les produits `active` des
+producteurs vérifiés (SIRET ok + payouts ON + non en pause), dans leur fenêtre de
+disponibilité ; la recherche plein-texte (`search_vector` config `french` + index
+GIN) et les enums catégories/labels/packaging sont en place. Les photos produit
+sont un tableau jsonb public-readable sur `products`.
+
+Le vrai blocage est ailleurs : la table `producers` n'a **que**
+`producers_select_self` — aucune lecture publique. Un acheteur ne peut donc pas
+lire le nom/ville du producteur pour afficher « Pierre Dupont · Évreux » sur les
+cartes. KAN-28 doit introduire un **chemin de lecture publique catalogue** (vue
+ou RPC) exposant une projection whitelistée produit + producteur public, qui
+réutilise le prédicat de visibilité de `products_select_public`.
+
+Tout ce qui dépend des **trajets / du matching** (badges « 3 trajets » / « Demain »,
+section « Disponible cette semaine », filtres trajet/zone) n'est pas câblable :
+trajets (KAN-41) et pipeline opportunités (KAN-42) n'existent pas. Même posture
+qu'en KAN-19/27 : on livre l'enveloppe réelle (vrais produits, vraie recherche,
+vrais filtres catégorie/producteur) et on rend l'UI dépendante du matching en état
+neutre / différé.
+
+## Périmètre technique
+
+**In scope :**
+
+- **Shell acheteur** `apps/web/app/acheteur/layout.tsx` (header + nav desktop,
+  bottom-nav mobile), rétro-wrappe `/acheteur/profil` (KAN-25) et
+  `/acheteur/historique` (KAN-27) sans régression de leur gating
+- **AC-04** `/acheteur/catalogue` : grille de **vrais produits** (lecture
+  publique), recherche FTS, filtres **catégorie** et **producteur** opérationnels
+- **AC-03** `/acheteur` (accueil) : greeting + « Découvrir des producteurs »
+  (vrais producteurs vérifiés) ; sections « Disponible cette semaine » et
+  « Mes envies » rendues en état différé/empty
+- **AC-05** `/acheteur/catalogue/[id]` : fiche produit réelle (lecture publique)
+- **Contracts** : `CatalogueQuery` (q, category, producer, cursor, limit) +
+  `CataloguePublicProduct` (projection sûre)
+- **DB** : vue ou RPC de lecture publique catalogue (produit + producteur public)
+  + repo `catalogueRepo`
+- **API** : `GET /api/v1/catalogue` (liste filtrée + paginée, SSR initial puis
+  filtrage client)
+
+**Out of scope (cette US) :**
+
+- Filtre de **matchabilité par trajet** (règle PRD §12 H3 : ≥ 2 trajets/30 j
+  ou ≥ 1 trajet actif) — trajets KAN-41, opportunités KAN-42 inexistants
+- Badges trajet/match (« 3 trajets », « Demain », « Match probable jeudi »),
+  section « Disponible cette semaine » alimentée, filtres « Zone d'origine » /
+  « Disponibilité » / « Trajet actif » → différés KAN-42
+- Wishlist « Mes envies » + bouton cœur (ajout aux envies) → KAN-30
+- Bascule état vide « zone non couverte » AC-12 → KAN-29
+- Notes / avis producteur (4.9 ★) et profil public producteur → KAN-52 / KAN-53
+- Version mobile native (Expo) — web d'abord, cohérent KAN-25/26/27
+
+## Hypothèses
+
+- Au MVP, le catalogue affiche **tous les produits publiquement visibles**
+  (prédicat `products_select_public`), **sans** filtrage par trajet. Le cadre
+  « Produits matchables sur votre zone » et les badges trajet deviennent différés.
+  ⚠️ Écart assumé vs règle métier maquette/PRD §12 H3 — dette temporaire câblée
+  par KAN-42 (à acter en décision produit si validé).
+- Le filtre « Zone d'origine » est différé (la géo = couche matching, buffer
+  10 km KAN-42) ; la zone acheteur (KAN-25) n'est pas encore appliquée au tri.
+- La projection producteur public est limitée aux champs sûrs (nom d'affichage,
+  ville) — jamais SIRET / identifiants Stripe / adresse exacte de collecte.
+- Gating `/acheteur/*` = rôle `acheteur` (calqué KAN-25/27), même si la RLS
+  autorise `anon` ; un catalogue public/SEO reste un sujet post-MVP.
+- KAN-28 est volumineux (shell + 3 écrans + chemin de lecture publique). Si la
+  charge est jugée trop forte, candidat à un découpage AC-04/05 (catalogue) /
+  AC-03 (accueil) — à arbitrer, le ticket Jira restant unitaire par défaut.

--- a/specs/KAN-28/tasks.md
+++ b/specs/KAN-28/tasks.md
@@ -1,0 +1,36 @@
+# Tâches techniques internes — KAN-28 Catalogue filtré
+
+> Ces tâches ne sont pas dans Jira. Setup, migrations, refacto, helpers
+> partagés, seeds, configuration — tout ce qui n'a pas vocation à être tracké
+> comme livrable produit.
+>
+> Subtasks Jira existantes (rappel — ne pas dupliquer ici) :
+> (aucune)
+
+## Tâches
+
+- [ ] **Décision DB** : arbitrer vue `public.catalogue_products` vs RPC
+      `catalogue_search` / `catalogue_get` (SECURITY DEFINER). Acter le choix et,
+      s'il est structurant, ajouter une entrée ARCHITECTURE.md §18.
+- [ ] Factoriser le **prédicat de visibilité** (`products_select_public`) en
+      fonction SQL réutilisable par la policy ET la vue/RPC (anti-divergence).
+- [ ] Migration : vue/RPC catalogue public (projection whitelistée produit +
+      producteur), tri FTS (`websearch_to_tsquery('french')` + `ts_rank`),
+      pagination cursor. + tests SQL de visibilité et de non-exposition.
+- [ ] `catalogueRepo` dans `packages/db` (+ types de projection, mapper DB→DTO).
+- [ ] Contracts `CatalogueQuery` + `CataloguePublicProduct` (+ tests).
+- [ ] Endpoint `GET /api/v1/catalogue` (validation Zod, pagination, codes
+      d'erreur).
+- [ ] **Shell** `acheteur/layout.tsx` + rétro-wrap `/acheteur/profil` et
+      `/acheteur/historique` ; vérifier non-régression gating KAN-25/27.
+- [ ] Composants `components/buyer/catalogue/*` (cards, search, chips filtres
+      actifs/différés) et `components/buyer/home/*` (sections AC-03 réelles +
+      différées).
+- [ ] Pages `acheteur/page.tsx`, `acheteur/catalogue/page.tsx`,
+      `acheteur/catalogue/[id]/page.tsx` (gating rôle acheteur).
+- [ ] Seeds/fixtures E2E : producteur vérifié (SIRET + payouts) + produits
+      `active` pour alimenter le catalogue de test.
+
+## Checklist pre-merge
+
+Voir ARCHITECTURE.md §14.3 — ne pas dupliquer ici.


### PR DESCRIPTION
Cadrage technique de **KAN-28 — Catalogue filtré** (écrans AC-03 accueil, AC-04 catalogue parcourable, AC-05 fiche produit + shell acheteur).

Trois specs dans `specs/KAN-28/` :
- `proposal.md` — périmètre, hypothèses
- `design.md` — conception technique (packages, modèle de données, API, UI, risques, tests)
- `tasks.md` — tâches techniques internes

### Points saillants
- La couche données catalogue existe déjà : RLS `products_select_public` (KAN-20), FTS `search_vector` (config `french`), enums catégories/labels/packaging, photos jsonb public-readable.
- Blocage central : `producers` n'a que `producers_select_self` → KAN-28 introduit un **chemin de lecture publique catalogue** (vue/RPC SECURITY DEFINER, projection whitelistée) réutilisant le prédicat de visibilité existant.
- KAN-28 pose aussi le **shell acheteur** (`acheteur/layout.tsx`) que KAN-25/27 ont différé.
- Tout ce qui dépend des trajets/matching (badges trajet, section « Disponible cette semaine », filtres zone/disponibilité), la wishlist (KAN-30), les avis (KAN-52/53) et AC-12 (KAN-29) sont **différés** — posture KAN-19/27.
- ⚠️ Écart assumé vs règle métier PRD §12 H3 (catalogue non filtré par trajet au MVP) — dette temporaire câblée par KAN-42.

Mapping `produit/jira_mapping.md` mis à jour (AC-03/04/05 + ligne KAN-28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qsbhz5sbgu17JrdwvRyMmy)_